### PR TITLE
Use https in a link of definitelytyped.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A central repository for sharing type definitions for Ruby gems
 
-Inspired by [definitelytyped.org](http://definitelytyped.org/).
+Inspired by [definitelytyped.org](https://definitelytyped.org/).
 Used in conjunction with [Sorbet](https://sorbet.org).
 
 ## Installation


### PR DESCRIPTION
Because `definitelytyped.org` seems not to use HSTS (HTTP Strict Transport Security).