### PR TITLE
Type ActiveRecord::Relation as a generic enumerable

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -7,3 +7,14 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
   def change_column(table_name, column_name, type, options = nil); end
   def create_table(table_name, options = nil); end
 end
+
+class ActiveRecord::Relation
+  extend T::Sig
+  extend T::Generic
+  include Enumerable
+
+  Elem = type_member
+
+  sig{params(block: T.proc.params(e: Elem).void).void}
+  def each(&block); end
+end


### PR DESCRIPTION
ActiveRecord::Relation is an Enumerable collection. This change allow a relation to be typed with its data and behave like a typed Enumerable.

Collection Type checking:
```
[dev@ip-10-0-0-61 traject (sorbet_beta_2)]$ srb tc
app/models/college_requirement_section.rb:10: ActiveRecord::Relation[CollegeRequirementSlot] doesn't match T::Enumerable[CollegeRequirementGroup] for argument arg0 http://go/e/7002
    10 |      [group] + group.slots
              ^^^^^^^^^^^^^^^^^^^^^
    https://github.com/stripe/sorbet/tree/f139b349612f0ba5005c1ff792f5cba134009d8e/rbi/core/array.rbi#L40: Method Array#+ has specified arg0 as T::Enumerable[CollegeRequirementGroup]
    40 |        arg0: T::Enumerable[Elem],
                ^^^^
  Got ActiveRecord::Relation[CollegeRequirementSlot] originating from:
    app/models/college_requirement_section.rb:10:
    10 |      [group] + group.slots
                        ^^^^^^^^^^^
```

Element typing:
```
app/models/test.rb:14: Revealed type: KnowDo http://go/e/7014
    14 |T.reveal_type(s.know_dos)
        ^^^^^^^^^^^^^^^^^^^^^^^^^
  From:
    app/models/test.rb:14:
    14 |T.reveal_type(s.know_dos)
                      ^^^^^^^^^^

app/models/test.rb:15: Revealed type: KnowDo  http://go/e/7014
    15 |s.know_dos.map { |kd| T.reveal_type(kd) }
                              ^^^^^^^^^^^^^^^^^
  From:
    app/models/test.rb:15:
    15 |s.know_dos.map { |kd| T.reveal_type(kd) }
```