### PR TITLE
delete hooks file

### DIFF
--- a/lib/sorbet-types/all/types/hooks.rbi
+++ b/lib/sorbet-types/all/types/hooks.rbi
@@ -1,6 +1,0 @@
-# typed: strict
-
-module T::Hooks
-  sig { params(pass_self_here: T.untyped).void }
-  def self.install(pass_self_here); end
-end


### PR DESCRIPTION
I don't think we need this anymore as it is in `sorbet-runtime`