### PR TITLE
Update state_machines-activemodel.rbi

### DIFF
--- a/lib/state_machines-activemodel/all/state_machines-activemodel.rbi
+++ b/lib/state_machines-activemodel/all/state_machines-activemodel.rbi
@@ -1,0 +1,7 @@
+class StateMachines::StateContext < Module
+  sig { params(args: T.untyped).void }
+  def validate(*args); end
+
+  sig { params(args: T.untyped).void }
+  def validates(*args); end
+end


### PR DESCRIPTION
Extension for `state_machines` that allows one to add ActiveModel validations on a per-state basis:

```ruby
class MyModel
  state_machine :state, initial: 'unauthorized' do
    event :authorize do
      transition 'unauthorized' => 'authorized'
    end

    state 'authorized' do
      validates :authorized_at, presence: true
    end
  end
end
```

https://github.com/state-machines/state_machines-activemodel

Related to https://github.com/sorbet/sorbet-typed/pull/15