### PR TITLE
Add # typed: strong to rbi files with missing typed

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -1,3 +1,5 @@
+# typed: strong
+
 class ActionDispatch::Routing::RouteSet
   sig {params(blk: T.proc.bind(ActionDispatch::Routing::Mapper).void).void}
   def draw(&blk); end

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1,3 +1,5 @@
+# typed: strong
+
 class ActiveRecord::Schema
   sig {params(info: Hash, blk: T.proc.bind(ActiveRecord::Schema).void).void}
   def self.define(info = nil, &blk); end

--- a/lib/activerecord/~>5.2/activerecord.rbi
+++ b/lib/activerecord/~>5.2/activerecord.rbi
@@ -1,1 +1,3 @@
+# typed: strong
+
 ActiveRecord::Migration::Compatibility::V5_2 = ActiveRecord::Migration::Current

--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -1,3 +1,5 @@
+# typed: strong
+
 module ActiveSupport
   sig {params(kind: Symbol, blk: T.proc.bind(T.class_of(ActionController::Base)).void).void}
   def self.on_load(kind, &blk); end

--- a/lib/railties/all/railties.rbi
+++ b/lib/railties/all/railties.rbi
@@ -1,3 +1,5 @@
+# typed: strong
+
 module Rails
   sig {returns(Rails::Application)}
   def self.application; end


### PR DESCRIPTION
We need # typed: strong so that it works when rerunning `srb rbi sorbet-typed`

Currently `srb rbi sorbet-typed` would copies files from the repo & remove `# typed: strong` in these files. The files will then cause errors like following:
```
./sorbet/rbi/sorbet-typed/lib/activesupport/all/activesupport.rbi:9: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none) http://go/e/5038
     9 |  sig {params(kind: Symbol, blk: T.proc.bind(T.class_of(ActionController::Base)).void).void}
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
We would not run into this problem by adding # typed: strong to original files in `sorbet-typed` repo
