### PR TITLE
fix the sig of in? in ActiveSupport.rbi

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -18,8 +18,8 @@ class Object
   sig {params(key: String).returns(String)}
   def to_query(key); end
 
-  sig {returns(T::Boolean)}
-  def in?; end
+  sig {params(another_object: Object).returns(T::Boolean)}
+  def in?(another_object); end
 
   sig {returns(T::Hash[String, T.untyped])}
   def instance_values; end


### PR DESCRIPTION
The sig is missing a param. See the source here:

https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/core_ext/object/inclusion.rb#L12