### PR TITLE
define Elem to fix Bundler::GemHelpers::PlatformMatch

### DIFF
--- a/lib/bundler/all/bundler.rbi
+++ b/lib/bundler/all/bundler.rbi
@@ -3336,6 +3336,9 @@ module Bundler::GemHelpers
 end
 
 class Bundler::GemHelpers::PlatformMatch < Struct
+  extend T::Generic
+  Elem = type_member(fixed: T.untyped)
+
   EXACT_MATCH = ::T.let(nil, ::T.untyped)
   WORST_MATCH = ::T.let(nil, ::T.untyped)
 


### PR DESCRIPTION
Fix per discussions in issue #19. 
It doesn't work when I use `type_member(:out, fixed: T.untyped)` but `type_member(fixed: T.untyped)` works
https://github.com/sorbet/sorbet-typed/issues/19