### PR TITLE
Add more ActiveSupport Object core extensions

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -6,8 +6,29 @@ module ActiveSupport
 end
 
 class Object
+  sig { params(duck: T.any(String, Symbol)).returns(T::Boolean) }
+  def acts_like?(duck); end
+
   sig {returns(T::Boolean)}
   def blank?; end
+
+  sig { returns(T.self_type) }
+  def deep_dup; end
+
+  sig { returns(TrueClass) }
+  def duplicable?; end
+
+  sig {params(another_object: Object).returns(T::Boolean)}
+  def in?(another_object); end
+
+  sig {returns(T::Hash[String, T.untyped])}
+  def instance_values; end
+
+  sig {returns(T::Array[String])}
+  def instance_variable_names; end
+
+  sig { returns(T.nilable(T.self_type)) }
+  def presence; end
 
   sig {returns(T::Boolean)}
   def present?; end
@@ -18,12 +39,62 @@ class Object
   sig {params(key: String).returns(String)}
   def to_query(key); end
 
-  sig {params(another_object: Object).returns(T::Boolean)}
-  def in?(another_object); end
+  sig do
+    params(
+      method_name: T.any(Symbol, String, NilClass),
+      args: T.untyped,
+      b: T.proc.params(arg0: T.untyped).returns(T.untyped)
+    ).returns(T.untyped)
+  end
+  def try(method_name = nil, *args, &b); end
 
-  sig {returns(T::Hash[String, T.untyped])}
-  def instance_values; end
+  sig do
+    params(
+      method_name: T.any(Symbol, String, NilClass),
+      args: T.untyped,
+      b: T.proc.params(arg0: T.untyped).returns(T.untyped)
+    ).returns(T.untyped)
+  end
+  def try!(method_name = nil, *args, &b); end
 
-  sig {returns(T::Array[String])}
-  def instance_variable_names; end
+  sig do
+    params(
+      options: Hash,
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).returns(T.untyped)
+  end
+  def with_options(options, &block); end
+end
+
+class FalseClass
+  sig { returns(NilClass) }
+  def presence; end
+end
+
+class Method
+  sig { returns(FalseClass) }
+  def duplicable?; end
+end
+
+class NilClass
+  sig { returns(T::Boolean) }
+  def duplicable?; end
+
+  sig do
+    params(
+      method_name: T.any(Symbol, String, NilClass),
+      args: T.untyped,
+      b: T.proc.params(arg0: T.untyped).returns(T.untyped)
+    ).returns(NilClass)
+  end
+  def try(method_name = nil, *args, &b) ; end
+
+  sig do
+    params(
+      method_name: T.any(Symbol, String, NilClass),
+      args: T.untyped,
+      b: T.proc.params(arg0: T.untyped).returns(T.untyped)
+    ).returns(NilClass)
+  end
+  def try!(method_name = nil, *args, &b) ; end
 end


### PR DESCRIPTION
Add sigs for more [ActiveSupport Object extensions](https://guides.rubyonrails.org/active_support_core_extensions.html#extensions-to-all-objects): `acts_like`,  `deep_dup`, `duplicable?`, `presence`, `try`, `try!`, `with_options`.