### PR TITLE
Add more methods to ActiveRecord::Base

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -31,6 +31,24 @@ class ActiveRecord::Base
     validate: nil,
     optional: nil
   ); end
+
+  sig { params(args: T.untyped).void }
+  def self.before_create(args); end
+
+  sig { params(args: T.untyped).void }
+  def run_callbacks(args); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).void }
+  def self.validates(*args, **kwargs); end
+
+  sig { params(args: T.untyped).void }
+  def update(args); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).void }
+  def update!(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).void }
+  def update_attributes(*args, **kwargs); end
 end
 
 class ActiveRecord::Schema


### PR DESCRIPTION
Param typing is pretty weak, but we can improve them in the future