### PR TITLE
Ensure that every #each accepts a &blk parameter

### DIFF
--- a/lib/bundler/all/bundler.rbi
+++ b/lib/bundler/all/bundler.rbi
@@ -4130,8 +4130,13 @@ class Bundler::Molinillo::DependencyGraph
   end
   def detach_vertex_named(name); end
 
-  sig {returns(::T.untyped)}
-  def each(); end
+  sig do
+    params(
+      blk: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def each(&blk); end
 
   sig {returns(::T.untyped)}
   def initialize(); end
@@ -4524,8 +4529,13 @@ class Bundler::Molinillo::DependencyGraph::Log
   end
   def detach_vertex_named(graph, name); end
 
-  sig {returns(::T.untyped)}
-  def each(); end
+  sig do
+    params(
+      blk: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def each(&blk); end
 
   sig {returns(::T.untyped)}
   def initialize(); end


### PR DESCRIPTION
This is for compatibility with newer, more pervasive abstract checks, which want everything enumerable to precisely match the abstract signature of `def each`.