### PR TITLE
Add Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![BuildStatus](https://travis-ci.org/sorbet/sorbet-typed.svg?branch=master)](https://travis-ci.org/sorbet/sorbet-typed)
+
 # sorbet-typed
 
 > A central repository for sharing type definitions for Ruby gems


### PR DESCRIPTION
This will add a passing/failing badge based on the Travis build (and should also be the first commit since merging `.travis.yml`, which should also start the Travis builds in general.)