### PR TITLE
Add "validates" method to ActiveRecord::Base

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -441,6 +441,20 @@ class ActiveRecord::Base
     unless: nil,
     on: nil
   ); end
+
+  sig do
+    params(
+      name: Symbol,
+      presence: T.nilable(T::Boolean),
+      inclusion: T::Array[T.any(String, Symbol)]
+    ).void
+  end
+  def self.validates(
+    name,
+    presence: nil,
+    inclusion: nil
+  )
+  end
 end
 
 module ActiveRecord::Inheritance::ClassMethods


### PR DESCRIPTION
Base type definition for the `validates` method.  We can add to it more as a larger surface of the validates method API can be used as a reference for the types.