### PR TITLE
Add T::Boolean to ActiveRecord's rbi for polymorphic support

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -128,7 +128,7 @@ module ActiveRecord::Associations::ClassMethods
       foreign_type: T.nilable(T.any(Symbol, String)),
       inverse_of: T.nilable(T.any(Symbol, String)),
       optional: T.nilable(T::Boolean),
-      polymorphic: T.nilable(T.any(Symbol, String)),
+      polymorphic: T.nilable(T.any(Symbol, String, T::Boolean)),
       primary_key: T.nilable(T.any(Symbol, String)),
       required: T.nilable(T::Boolean),
       touch: T.nilable(T::Boolean),

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -128,7 +128,7 @@ module ActiveRecord::Associations::ClassMethods
       foreign_type: T.nilable(T.any(Symbol, String)),
       inverse_of: T.nilable(T.any(Symbol, String)),
       optional: T.nilable(T::Boolean),
-      polymorphic: T.nilable(T.any(Symbol, String, T::Boolean)),
+      polymorphic: T.nilable(T::Boolean),
       primary_key: T.nilable(T.any(Symbol, String)),
       required: T.nilable(T::Boolean),
       touch: T.nilable(T::Boolean),


### PR DESCRIPTION
Fix to support polymorphic

```bash
Expected T.nilable(T.any(Symbol, String)) but found TrueClass for argument polymorphic https://srb.help/7002
     4 |  belongs_to :item, polymorphic: true
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```