### PR TITLE
Improve sigs for ActiveRecord `validate`

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -25,6 +25,7 @@ module ActiveModel::Validations
         on: T.any(Symbol, String),
         prepend: T::Boolean,
         unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        blk: T.nilable(T.proc.params(arg0: T.untyped).void)
       ).void
     end
     def validate(

--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -29,10 +29,11 @@ module ActiveModel::Validations
     end
     def validate(
       *names,
-      if: nil,
-      on: nil,
-      prepend: T::Boolean,
-      unless: nil
+      if: :_,
+      on: :_,
+      prepend: false,
+      unless: :_,
+      &blk
     ); end
 
     # https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations/validates.rb#L75-L105


### PR DESCRIPTION
Fixes a couple issues:

1) `:presence, :inclusion, :allow_nil` aren't allowed keywords for `validate`—they're only allowed in `validates.`

```ruby
>> class Foo < ActiveRecord::Base; validate :bar, presence: true; end
ArgumentError: Unknown key: :presence. Valid keys are: :on, :if, :unless, :prepend. Perhaps you meant to call `validates` instead of `validate`?
```

2) `validate` takes positional args as a splat, which sorbet [doesn't fully handle yet](https://sorbet.org/docs/error-reference#7019). Notably it doesn't actually accept an array as a first arg. That would throw an error: 

```ruby
>> class Foo < ActiveRecord::Base; validate([:bar, :baz]); end
>> Foo.new.valid?
NoMethodError: undefined method `validate' for [:bar, :baz]:Array
```

~~3) None of the optional keyword args actually need to be `nilable`—they have default values in the method definition itself, so sorbet will allow them to be omitted. I'd argue we don't actually want to allow `nil` to be passed in as a value, so I made them all non-nilable.~~

**EDIT** I was wrong about this! [Sorbet.run doesn't allow this syntax](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Asig%20%7B%20params(bar%3A%20String).void%20%7D%0Adef%20foo(bar%3A%20nil)%3B%20end%0A%0Afoo()%0A), but my version of Sorbet (`0.4.4429`) _does_. Is this a sorbet bug?