### PR TITLE
Move ActiveRecord::Base methods into their actual modules and include/extend them explicitly

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -4,13 +4,85 @@ module ActiveModel::Dirty
   extend T::Sig
   sig { params(attr: Symbol, from: T.untyped, to: T.untyped).returns(T::Boolean) }
   def attribute_changed?(attr, from: nil, to: nil); end
-  
+
   sig { params(attr_name: Symbol).returns(T::Boolean) }
   def attribute_changed_in_place?(attr_name); end
-  
+
   sig { params(attr_name: Symbol).returns(T::Boolean) }
   def attribute_previously_changed?(attr_name); end
-  
+
   sig { returns(T::Boolean) }
   def changed?; end
+end
+
+module ActiveModel::Validations
+  module ClassMethods
+    # https://github.com/rails/rails/blob/c8910a90f/activemodel/lib/active_model/validations.rb#L131-L152
+    sig do
+      params(
+        names: T.any(Symbol, String),
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String),
+        prepend: T::Boolean,
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      ).void
+    end
+    def validate(
+      *names,
+      if: nil,
+      on: nil,
+      prepend: T::Boolean,
+      unless: nil
+    ); end
+
+    # https://github.com/rails/rails/blob/c8910a90f/activemodel/lib/active_model/validations/validates.rb#L75-L105
+    sig do
+      params(
+        names: T.any(T::Array[Symbol], Symbol),
+        absence: T.nilable(T::Boolean),
+        acceptance: T.any(T::Boolean, Hash),
+        confirmation: T.any(T::Boolean, Hash),
+        exclusion: T.nilable(Hash),
+        format: T.nilable(Hash),
+        length: T.nilable(Hash),
+        numericality: T.any(T::Boolean, Hash),
+        presence: T.nilable(T::Boolean),
+        inclusion: T.any(
+          T::Array[T.any(String, Symbol)],
+          { in: T::Array[T.any(Symbol, String, T::Boolean, NilClass)]}
+        ),
+        size: T.nilable(Hash),
+        uniqueness: T.any(
+          T::Boolean,
+          {
+            scope: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+            case_sensitive: T::Boolean
+          }
+        ),
+        unless: T.nilable(Symbol),
+        if: T.nilable(Symbol),
+        allow_nil: T.nilable(T::Boolean),
+        on: T.nilable(Symbol)
+      ).void
+    end
+    def validates(
+      *names,
+      absence: nil,
+      acceptance: nil,
+      confirmation: nil,
+      exclusion: nil,
+      format: nil,
+      length: nil,
+      numericality: nil,
+      presence: nil,
+      inclusion: nil,
+      size: nil,
+      uniqueness: nil,
+      on: nil,
+      unless: nil,
+      if: nil,
+      allow_nil: nil
+    )
+    end
+  end
 end

--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -17,7 +17,7 @@ end
 
 module ActiveModel::Validations
   module ClassMethods
-    # https://github.com/rails/rails/blob/c8910a90f/activemodel/lib/active_model/validations.rb#L131-L152
+    # https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations.rb#L131-L152
     sig do
       params(
         names: T.any(Symbol, String),
@@ -35,7 +35,7 @@ module ActiveModel::Validations
       unless: nil
     ); end
 
-    # https://github.com/rails/rails/blob/c8910a90f/activemodel/lib/active_model/validations/validates.rb#L75-L105
+    # https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations/validates.rb#L75-L105
     sig do
       params(
         names: T.any(T::Array[Symbol], Symbol),

--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -17,7 +17,7 @@ end
 
 module ActiveModel::Validations
   module ClassMethods
-    # https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations.rb#L131-L152
+    # https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations.rb#L136-L154
     sig do
       params(
         names: T.any(Symbol, String),


### PR DESCRIPTION
### Why

Previously we'd just defined a lot of methods right inside `ActiveRecord::Base`—that worked initially but it's not correct or modular. If someone tried to include `ActiveModel::Validations::ClassMethods` directly, e.g., they wouldn't get our signatures correctly.

### How

This changeset just moves around those signatures into something more like the actual byzantine module hierarchy Rails uses.

### A Caveat on `Concerns`

Rails uses `Concerns` a lot, which is hard to model using Sorbet. When you `include` a `FooConcern`, `FooConcern` will try to automatically `extend`  your class with `FooConcern::ClassMethods`. Sorbet has [`mixes_in_class_methods`](https://sorbet.org/docs/abstract#interfaces-and-the-included-hook) to model modules that `extend` your class via their `included` hook, but I don't know of any way to model transitive `include`s (modules that include another module in their `included` hook). So I just explicitly listed those all as `includes` in `ActiveRecord::Base` and added comments to document that I hand-wrote them. It's not ideal!