### PR TITLE
Update ActiveRecord to remove 5.2 classes from all

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -234,6 +234,13 @@ module ActiveRecord::Scoping::Named::ClassMethods
   ); end
 end
 
+module ActiveRecord::Scoping::Default::ClassMethods
+end
+
+module ActiveRecord::Inheritance
+  mixes_in_class_methods(ActiveRecord::Inheritance::ClassMethods)
+end
+
 class ActiveRecord::Base
   extend ActiveModel::Naming
 
@@ -247,8 +254,6 @@ class ActiveRecord::Base
   extend ActiveRecord::DynamicMatchers
   extend ActiveRecord::Explain
   extend ActiveRecord::Enum
-  extend ActiveRecord::Delegation::DelegateCache
-  extend ActiveRecord::CollectionCacheKey
 
   include ActiveRecord::Core
   include ActiveRecord::Persistence
@@ -270,7 +275,6 @@ class ActiveRecord::Base
   include ActiveRecord::AttributeDecorators
   include ActiveRecord::Locking::Optimistic
   include ActiveRecord::Locking::Pessimistic
-  include ActiveRecord::DefineCallbacks
   include ActiveRecord::AttributeMethods
   include ActiveRecord::AttributeMethods::Read # via ActiveRecord::AttributeMethods#included hook
   include ActiveRecord::AttributeMethods::Write # via ActiveRecord::AttributeMethods#included hook
@@ -290,13 +294,10 @@ class ActiveRecord::Base
   extend ActiveRecord::NestedAttributes::ClassMethods # via ActiveRecord::NestedAttributes Concern inclusion
   include ActiveRecord::Aggregations
   include ActiveRecord::Transactions
-  include ActiveRecord::TouchLater
   include ActiveRecord::NoTouching
   include ActiveRecord::Reflection
   include ActiveRecord::Serialization
   include ActiveRecord::Store
-  include ActiveRecord::SecureToken
-  include ActiveRecord::Suppressor
 
   sig do
     params(

--- a/lib/activerecord/~>5.2/activerecord.rbi
+++ b/lib/activerecord/~>5.2/activerecord.rbi
@@ -1,3 +1,12 @@
 # typed: strong
 
 ActiveRecord::Migration::Compatibility::V5_2 = ActiveRecord::Migration::Current
+
+class ActiveRecord::Base
+  extend ActiveRecord::Delegation::DelegateCache
+  extend ActiveRecord::CollectionCacheKey
+  include ActiveRecord::DefineCallbacks
+  include ActiveRecord::TouchLater
+  include ActiveRecord::SecureToken
+  include ActiveRecord::Suppressor
+end


### PR DESCRIPTION
1) Added `ActiveRecord::Inheritance::ClassMethods` mixin so that we can use `self.abstract_class =`
2) Move 5.2 only classes out of `all`.