### PR TITLE
Added options to PaperTrail::Model::ClassMethods#has_paper_trail

### DIFF
--- a/lib/paper_trail/all/paper_trail.rbi
+++ b/lib/paper_trail/all/paper_trail.rbi
@@ -1,7 +1,7 @@
 # typed: strong
 
 module PaperTrail::Model::ClassMethods
-  def has_paper_trail
+  def has_paper_trail(options = {})
   end
 end
 


### PR DESCRIPTION
Fixes passing options to the `has_paper_trail` method.

Defined here: https://github.com/paper-trail-gem/paper_trail/blob/master/lib/paper_trail/has_paper_trail.rb#L66