### PR TITLE
Fix small bug in type signature of `ActiveRecord::Type::Boolean#cast`

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -774,7 +774,7 @@ class ActiveRecord::Type::Boolean < ActiveRecord::Type::Value
   def initialize(args = nil); end
 
   sig { params(value: T.untyped).returns(T.nilable(T::Boolean)) }
-  def cast(value: T.untyped); end
+  def cast(value); end
 end
 
 module ActiveRecord


### PR DESCRIPTION
This was a copy-pasted error I added this in #38. The method stub shouldn't have a Sorbet type. :\

