### PR TITLE
Type Grape

### DIFF
--- a/lib/grape/all/grape.rbi
+++ b/lib/grape/all/grape.rbi
@@ -222,4 +222,3 @@ class Grape::API
   def self.format(format)
   end
 end
-

--- a/lib/grape/all/grape.rbi
+++ b/lib/grape/all/grape.rbi
@@ -1,0 +1,225 @@
+# typed: strong
+
+class Virtus::Attribute::Boolean
+end
+
+class Grape::API
+  Boolean = Virtus::Attribute::Boolean
+
+  sig do
+    params(
+      name: Symbol,
+      type: T.untyped,
+      desc: String,
+      allow_blank: T::Boolean,
+      values: T::Array[T.untyped],
+      date_parameter: T::Boolean,
+      positive_number: T::Boolean,
+      acord130_question_number: T::Boolean,
+      id_for_entity_type: T.untyped,
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.requires(
+    name,
+    type: String,
+    desc: nil,
+    allow_blank: nil,
+    values: nil,
+    date_parameter: nil,
+    positive_number: nil,
+    acord130_question_number: nil,
+    id_for_entity_type: nil,
+    &block)
+  end
+
+  sig do
+    params(
+      name: Symbol,
+      type: T.untyped,
+      allow_blank: T::Boolean,
+      values: T::Array[T.untyped],
+      date_parameter: T::Boolean,
+      positive_number: T::Boolean,
+      acord130_question_number: T::Boolean,
+      percent_parameter: T::Boolean,
+      id_for_entity_type: T.untyped,
+      desc: String
+    ).void
+  end
+  def self.optional(
+    name,
+    type: String,
+    desc: nil,
+    allow_blank: nil,
+    values: nil,
+    date_parameter: nil,
+    positive_number: nil,
+    acord130_question_number: nil,
+    percent_parameter: nil,
+    id_for_entity_type: nil,
+    &block
+    )
+  end
+
+  sig do
+    params(
+      block: T.nilable(T.proc.void)
+    ).returns(Hash)
+  end
+  def self.params(&block)
+  end
+
+  sig do
+    params(
+      route: String,
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.put(route, &block)
+  end
+
+  sig do
+    params(
+      conditional: Symbol,
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.given(conditional, &block)
+  end
+
+
+  sig do
+    params(
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.helpers(&block)
+  end
+
+  sig do
+    params(
+      route: String,
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.post(route, &block)
+  end
+
+  sig do
+    params(
+      route: String,
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.delete(route, &block)
+  end
+
+  sig do
+    params(
+      route_param_name: T.any(String, Symbol),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.route_param(route_param_name, &block)
+  end
+
+  sig do
+    params(
+      route: String,
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.get(route = nil, &block)
+  end
+
+  sig do
+    params(
+      space: T.any(T.nilable(Symbol), T.nilable(String)),
+      options: T.nilable(Hash)
+    ).void
+  end
+  def self.resource(space = nil, options = {})
+  end
+
+  sig do
+    params(
+      space: T.any(T.nilable(Symbol), T.nilable(String)),
+      options: T.nilable(Hash)
+    ).void
+  end
+  def self.namespace(space = nil, options = {})
+  end
+
+
+  sig do
+    params(
+      space: T.any(T.nilable(Symbol), T.nilable(String)),
+      options: T.any(
+        T.nilable(Hash),
+        String,
+      )
+    ).void
+  end
+  def self.route(space = nil, options = {})
+  end
+
+  sig do
+    params(
+      space: T.any(T.nilable(Symbol), T.nilable(String)),
+      options: T.nilable(Hash)
+    ).void
+  end
+  def self.resources(space = nil, options = {})
+  end
+
+  sig do
+    params(
+      api_class: T.any(
+        T.class_of(Grape::API),
+        Hash
+      )
+    ).void
+  end
+  def self.mount(api_class)
+  end
+
+  sig do
+    params(
+      object: T.untyped,
+      with: T.nilable(T.class_of(Grape::Entity))
+    ).void
+  end
+  def self.present(object, with: nil)
+  end
+
+  sig do
+    params().returns(String)
+  end
+  def self.request_user_ip
+  end
+
+  sig do
+    params().returns(String)
+  end
+  def self.request_user_id
+  end
+
+  sig do
+    params(
+      error_string: String,
+      status_code: Integer
+    ).void
+  end
+  def self.error!(error_string, status_code)
+  end
+
+  sig do
+    params(
+      format: Symbol,
+    ).void
+  end
+  def self.format(format)
+  end
+end
+


### PR DESCRIPTION
Basic types for https://github.com/ruby-grape/grape

Some discussion about this here:
https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1563314645490800

> Hi everyone, I’ve been discussing an interesting thing around typing gems and code in general with @Jeff Carbonella.  I am typing this gem in `sorbet-typed`: https://github.com/ruby-grape/grape.
> 
> What we’re finding is this gem uses a lot of fairly complex, somewhat hard to follow meta-programming techniques to get methods into the `Grape::API` class that all of our own application API code inherits from.
> 
> Originally, I was trying to figure out all of the implementation details of how the methods got into there, and tried to type the gem based on implementation details.
> 
> Later, we realized that we can simply type the methods in `Grape::API` and forget about the implementation details entirely.  We felt this was better because:
> A) Types should serve as documentation and hide implementation detail
> B) The inside implementation of a gem should be considered private API, and we should only type public API
> C) Public API types are kind of like an “integration test” over a “unit test.”  We don’t really need to unit test our code — we just want to make sure the available API works as expected (this is similar to B).
> 
> We welcome any thoughts on this and are curious if there are any opposing opinions on it! (edited) 