### PR TITLE
Improve ActiveRecord::Persistence method signatures

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -522,36 +522,12 @@ end
 
 module ActiveRecord::Persistence
   mixes_in_class_methods(ActiveRecord::Persistence::ClassMethods)
-end
 
-module ActiveRecord::Persistence::ClassMethods
-  sig { params(klass: Class).returns(Class) }
+  sig { params(klass: Class).returns(T.untyped) }
   def becomes!(klass); end
 
-  sig { params(klass: Class).returns(Class) }
+  sig { params(klass: Class).returns(T.untyped) }
   def becomes(klass); end
-
-  sig do
-    params(
-      attributes: T.nilable(T.any(
-        T::Hash[T.any(Symbol, String), T.untyped],
-        T::Array[T::Hash[T.any(Symbol, String), T.untyped]]
-      )),
-      blk: T.nilable(T.proc.params(arg0: T.untyped).returns(T.untyped))
-    ).returns(T.any(Array, T.self_type))
-  end
-  def create!(attributes = nil, &blk); end
-
-  sig do
-    params(
-      attributes: T.nilable(T.any(
-        T::Hash[T.any(Symbol, String), T.untyped],
-        T::Array[T::Hash[T.any(Symbol, String), T.untyped]]
-      )),
-      blk: T.nilable(T.proc.params(arg0: T.untyped).returns(T.untyped))
-    ).returns(T.any(Array, T.self_type))
-  end
-  def create(attributes = nil, &blk); end
 
   sig do
     params(
@@ -569,27 +545,6 @@ module ActiveRecord::Persistence::ClassMethods
     ).returns(T.self_type)
   end
   def decrement(attribute, by = 1); end
-
-  sig do
-    params(
-      id_or_array: T.any(T.untyped, T::Array[T.untyped])
-    ).returns(T.self_type)
-  end
-  def delete(id_or_array); end
-
-  sig do
-    params(
-      id_or_array: T.any(T.untyped, T::Array[T.untyped])
-    ).returns(T.self_type)
-  end
-  def destroy!(id_or_array); end
-
-  sig do
-    params(
-      id_or_array: T.any(T.untyped, T::Array[T.untyped])
-    ).returns(T.self_type)
-  end
-  def destroy(id_or_array); end
 
   sig { returns(T::Boolean) }
   def destroyed?(); end
@@ -610,43 +565,6 @@ module ActiveRecord::Persistence::ClassMethods
     ).returns(T.self_type)
   end
   def increment(attribute, by = 1); end
-
-  sig do
-    params(
-      attributes: T::Array[T::Hash[T.any(Symbol, String), T.untyped]],
-      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)]))
-    ).returns(ActiveRecord::Result)
-  end
-  def insert_all!(attributes, returning: nil); end
-
-  sig do
-    params(
-      attributes: T::Array[T::Hash[T.any(Symbol, String), T.untyped]],
-      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)])),
-      unique_by: T.nilable(T.untyped)
-    ).returns(ActiveRecord::Result)
-  end
-  def insert_all(attributes, returning: nil, unique_by: nil); end
-
-  sig do
-    params(
-      attributes: T::Hash[T.any(Symbol, String), T.untyped],
-      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)])),
-      unique_by: T.nilable(T.untyped)
-    ).returns(ActiveRecord::Result)
-  end
-  def insert!(attributes, returning: nil, unique_by: nil); end
-
-  sig do
-    params(
-      attributes: T::Hash[T.any(Symbol, String), T.untyped],
-      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)])),
-      unique_by: T.nilable(T.untyped)
-    ).returns(ActiveRecord::Result)
-  end
-  def insert(attributes, returning: nil, unique_by: nil); end
-
-  def instantiate(attributes, column_types = {}, &blk); end
 
   sig { returns(T::Boolean) }
   def new_record?(); end
@@ -677,10 +595,10 @@ module ActiveRecord::Persistence::ClassMethods
   end
   def save(*args, &blk); end
 
-  sig { params(attribute: T.any(Symbol, String)).returns(T.self_type) }
+  sig { params(attribute: T.any(Symbol, String)).returns(TrueClass) }
   def toggle!(attribute); end
 
-  sig { params(attribute: T.any(Symbol, String)).returns(T::Boolean) }
+  sig { params(attribute: T.any(Symbol, String)).returns(T.self_type) }
   def toggle(attribute); end
 
   sig do
@@ -725,11 +643,97 @@ module ActiveRecord::Persistence::ClassMethods
   end
   def update!(attributes); end
 
+  alias update_attributes update
+  alias update_attributes! update!
+end
+
+module ActiveRecord::Persistence::ClassMethods
+  sig do
+    params(
+      attributes: T.nilable(T.any(
+        T::Hash[T.any(Symbol, String), T.untyped],
+        T::Array[T::Hash[T.any(Symbol, String), T.untyped]]
+      )),
+      blk: T.nilable(T.proc.params(arg0: T.untyped).returns(T.untyped))
+    ).returns(T.untyped)
+  end
+  def create!(attributes = nil, &blk); end
+
+  sig do
+    params(
+      attributes: T.nilable(T.any(
+        T::Hash[T.any(Symbol, String), T.untyped],
+        T::Array[T::Hash[T.any(Symbol, String), T.untyped]]
+      )),
+      blk: T.nilable(T.proc.params(arg0: T.untyped).returns(T.untyped))
+    ).returns(T.untyped)
+  end
+  def create(attributes = nil, &blk); end
+
+  sig do
+    params(
+      id_or_array: T.any(T.untyped, T::Array[T.untyped])
+    ).returns(T.untyped)
+  end
+  def delete(id_or_array); end
+
+  sig do
+    params(
+      id_or_array: T.any(T.untyped, T::Array[T.untyped])
+    ).returns(T.untyped)
+  end
+  def destroy!(id_or_array); end
+
+  sig do
+    params(
+      id_or_array: T.any(T.untyped, T::Array[T.untyped])
+    ).returns(T.untyped)
+  end
+  def destroy(id_or_array); end
+
+  sig do
+    params(
+      attributes: T::Array[T::Hash[T.any(Symbol, String), T.untyped]],
+      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)]))
+    ).returns(ActiveRecord::Result)
+  end
+  def insert_all!(attributes, returning: nil); end
+
+  sig do
+    params(
+      attributes: T::Array[T::Hash[T.any(Symbol, String), T.untyped]],
+      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)])),
+      unique_by: T.nilable(T.untyped)
+    ).returns(ActiveRecord::Result)
+  end
+  def insert_all(attributes, returning: nil, unique_by: nil); end
+
+  sig do
+    params(
+      attributes: T::Hash[T.any(Symbol, String), T.untyped],
+      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)])),
+      unique_by: T.nilable(T.untyped)
+    ).returns(ActiveRecord::Result)
+  end
+  def insert!(attributes, returning: nil, unique_by: nil); end
+
+  sig do
+    params(
+      attributes: T::Hash[T.any(Symbol, String), T.untyped],
+      returning: T.nilable(T.any(FalseClass, T::Array[T.any(Symbol, String)])),
+      unique_by: T.nilable(T.untyped)
+    ).returns(ActiveRecord::Result)
+  end
+  def insert(attributes, returning: nil, unique_by: nil); end
+
+  sig { params(attributes: T.untyped, column_types: Hash, blk: T.proc.void).returns(T.untyped) }
+  def instantiate(attributes, column_types = {}, &blk); end
+
   sig do
     params(
       id: T.any(T.untyped, T::Array[T.untyped], Symbol),
       attributes: T::Hash[T.any(Symbol, String), T.untyped]
-    ).returns(T.any(Array, T.self_type))
+    ).returns(T.any(Array, T.untyped))
   end
   def update(id = :all, attributes); end
 
@@ -750,9 +754,6 @@ module ActiveRecord::Persistence::ClassMethods
     ).returns(ActiveRecord::Result)
   end
   def upsert(attributes, returning: nil, unique_by: nil); end
-
-  alias update_attributes update
-  alias update_attributes! update!
 end
 
 class ActiveRecord::Result; end
@@ -1075,7 +1076,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     validate: nil
   ); end
 
-  # Indices 
+  # Indices
 
   sig do
     params(

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -639,9 +639,16 @@ module ActiveRecord::Persistence
   sig do
     params(
       attributes: T::Hash[T.any(Symbol, String), T.untyped]
-    ).returns(T::Boolean)
+    ).returns(TrueClass)
   end
   def update!(attributes); end
+
+  sig do
+    params(
+      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+    ).returns(T::Boolean)
+  end
+  def update(attributes); end
 
   alias update_attributes update
   alias update_attributes! update!


### PR DESCRIPTION
Improves some of the signatures for the `ActiveRecord::Persistence` module.

- `ActiveRecord::Persistence#becomes` should return `T.untyped`, not `Class`, since it'll try to return an instance of the specified class
- `ActiveRecord::Persistence#increment` actually returns `self`
- `ActiveRecord::Persistence#toggle` actually returns `self`
- `ActiveRecord::Persistence#toggle!` actually only returns `true` (or raises an error)
- `ActiveRecord::Persistence#update!` actually only returns `true` (or raises an error)
- None of the methods defined in `ClassMethods` can return `T.self_type`, because that'll actually refer to the class, not an instance. We can't generically specify that they should return an _instance_ of `T.self_type`, so they've gotta be T.untyped instead until that feature's implemented in Sorbet.
- The methods `becomes`, `becomes!`, `decrement`, `decrement!`, `increment`, `increment!`, `new_record?`, `persisted?`, `reload`, `save!`, `save`, `toggle!`, `toggle`, `touch`, `update_attribute`, `update_column`, `update_columns`, and `update` are instance methods defined in the `Persistence` module; they should never have been defined in `ClassMethods`. That was a bug!