### PR TITLE
Add more versions to ActiveRecord.

### DIFF
--- a/lib/activerecord/>=5.2/activerecord.rbi
+++ b/lib/activerecord/>=5.2/activerecord.rbi
@@ -1,7 +1,5 @@
 # typed: strong
 
-ActiveRecord::Migration::Compatibility::V5_2 = ActiveRecord::Migration::Current
-
 class ActiveRecord::Base
   extend ActiveRecord::Delegation::DelegateCache
   extend ActiveRecord::CollectionCacheKey

--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -1,0 +1,3 @@
+# typed: strong
+
+ActiveRecord::Migration::Compatibility::V5_2 = ActiveRecord::Migration::Current

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -1,0 +1,3 @@
+# typed: strong
+
+ActiveRecord::Migration::Compatibility::V6_0 = ActiveRecord::Migration::Current


### PR DESCRIPTION
Renamed ~>5.2 to >=5.2, since 6.0 also has these includes/extends.

And then I split the ActiveRecord version aliases between version-specific files.