### PR TITLE
Fix typo in `validate` method stub

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -31,7 +31,7 @@ module ActiveModel::Validations
       *names,
       if: nil,
       on: nil,
-      prepend: T::Boolean,
+      prepend: false,
       unless: nil
     ); end
 


### PR DESCRIPTION
This should've been `false` the whole time—that was a bug in my initial commit.