### PR TITLE
Make StateMachines::StateContext#state variadic

### DIFF
--- a/lib/state_machines/all/state_machines.rbi
+++ b/lib/state_machines/all/state_machines.rbi
@@ -26,7 +26,7 @@ class StateMachines::StateContext
       blk: T.proc.bind(StateMachines::StateContext).void,
     ).void
   end
-  def state(name, &blk); end
+  def state(*name, &blk); end
 
   sig do
     params(


### PR DESCRIPTION
`state` is a variadic method, so both of these should typecheck:

```ruby
state_machine do
  state 'active' do
    puts 'hello'
  end
  
  state 'active', 'inactive' do
    puts 'hello'
  end
end
```