### PR TITLE
 Removed trailing blanks on 1 line in activesupport.rbi file

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -128,7 +128,7 @@ class String
 
   sig { returns(String) }
   def demodulize; end
-  
+
   alias_method :ends_with?, :end_with?
 
   sig { params(string: String).returns(T::Boolean) }


### PR DESCRIPTION
 Removed trailing blanks on 1 line in activesupport.rbi file to avoid overcommit trigger.