### PR TITLE
Replace Thread with Process::Waiter for Open3

### DIFF
--- a/lib/ruby/all/open3.rbi
+++ b/lib/ruby/all/open3.rbi
@@ -5,8 +5,8 @@ module Open3
     params(
       cmd: T.any(String, T::Array[String]),
       opts: T::Hash[Symbol, T.untyped],
-      block: T.nilable(T.proc.params(stdin: IO, stdout: IO, stderr: IO, wait_thr: Thread).void)
-    ).returns([IO, IO, IO, Thread])
+      block: T.nilable(T.proc.params(stdin: IO, stdout: IO, stderr: IO, wait_thr: Process::Waiter).void)
+    ).returns([IO, IO, IO, Process::Waiter])
   end
   def self.popen3(*cmd, **opts, &block); end
 
@@ -14,8 +14,8 @@ module Open3
     params(
       cmd: T.any(String, T::Array[String]),
       opts: T::Hash[Symbol, T.untyped],
-      block: T.nilable(T.proc.params(stdin: IO, stdout: IO, wait_thr: Thread).void)
-    ).returns([IO, IO, Thread])
+      block: T.nilable(T.proc.params(stdin: IO, stdout: IO, wait_thr: Process::Waiter).void)
+    ).returns([IO, IO, Process::Waiter])
   end
   def self.popen2(*cmd, **opts, &block); end
 
@@ -23,8 +23,8 @@ module Open3
     params(
       cmd: T.any(String, T::Array[String]),
       opts: T::Hash[Symbol, T.untyped],
-      block: T.nilable(T.proc.params(stdin: IO, stdout_and_stderr: IO, wait_thr: Thread).void)
-    ).returns([IO, IO, Thread])
+      block: T.nilable(T.proc.params(stdin: IO, stdout_and_stderr: IO, wait_thr: Process::Waiter).void)
+    ).returns([IO, IO, Process::Waiter])
   end
   def self.popen2e(*cmd, **opts, &block); end
 
@@ -62,8 +62,8 @@ module Open3
     params(
       cmds: T.any(String, T::Array[String]),
       opts: T::Hash[Symbol, T.untyped],
-      block: T.nilable(T.proc.params(first_stdin: IO, last_stdout: IO, wait_threads: T::Array[Thread]).void)
-    ).returns([IO, IO, T::Array[Thread]])
+      block: T.nilable(T.proc.params(first_stdin: IO, last_stdout: IO, wait_threads: T::Array[Process::Waiter]).void)
+    ).returns([IO, IO, T::Array[Process::Waiter]])
   end
   def self.pipeline_rw(*cmds, **opts, &block); end
 
@@ -71,8 +71,8 @@ module Open3
     params(
       cmds: T.any(String, T::Array[String]),
       opts: T::Hash[Symbol, T.untyped],
-      block: T.nilable(T.proc.params(last_stdout: IO, wait_threads: T::Array[Thread]).void)
-    ).returns([IO, T::Array[Thread]])
+      block: T.nilable(T.proc.params(last_stdout: IO, wait_threads: T::Array[Process::Waiter]).void)
+    ).returns([IO, T::Array[Process::Waiter]])
   end
   def self.pipeline_r(*cmds, **opts, &block); end
 
@@ -80,8 +80,8 @@ module Open3
     params(
       cmds: T.any(String, T::Array[String]),
       opts: T::Hash[Symbol, T.untyped],
-      block: T.nilable(T.proc.params(first_stdin: IO, wait_threads: T::Array[Thread]).void)
-    ).returns([IO, T::Array[Thread]])
+      block: T.nilable(T.proc.params(first_stdin: IO, wait_threads: T::Array[Process::Waiter]).void)
+    ).returns([IO, T::Array[Process::Waiter]])
   end
   def self.pipeline_w(*cmds, **opts, &block); end
 
@@ -89,8 +89,8 @@ module Open3
     params(
       cmds: T.any(String, T::Array[String]),
       opts: T::Hash[Symbol, T.untyped],
-      block: T.nilable(T.proc.params(wait_threads: T::Array[Thread]).void)
-    ).returns(T::Array[Thread])
+      block: T.nilable(T.proc.params(wait_threads: T::Array[Process::Waiter]).void)
+    ).returns(T::Array[Process::Waiter])
   end
   def self.pipeline_start(*cmds, **opts, &block); end
 


### PR DESCRIPTION
Per documentation located at https://ruby-doc.org/stdlib-2.6.3/libdoc/open3/rdoc/Open3.html the `popen` and `pipeline` families of methods return `Process::Waiter` rather than `Thread`.  `Process::Waiter` inherits from `Thread` but also has a `#pid` method, so most code using Open3 is likely to have worked with the existing annotations.

The code examples in the official documentation would make suitable test cases for this change, since many of them invoke `#pid`