### PR TITLE
Add validates_x_of helper methods to ActiveModel

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -172,12 +172,25 @@ module ActiveModel::Validations::HelperMethods
     strict: false
   ); end
 
+  # A type alias for the in/within parameters on the
+  # validates_(inclusion/exclusion)_of methods.
+  InWithinType = T.type_alias(
+    T.nilable(
+      T.any(
+        Symbol,
+        String,
+        T::Array[T.any(String, Symbol)],
+        T::Range[Integer],
+        T.proc.params(arg0: T.untyped).returns(T::Boolean)
+      )
+    )
+  )
   sig do
     params(
       attr_names: T.any(String, Symbol),
       message: String,
-      in: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
-      within: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
+      in: InWithinType,
+      within: InWithinType,
       if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       on: T.any(Symbol, String),
@@ -232,8 +245,8 @@ module ActiveModel::Validations::HelperMethods
     params(
       attr_names: T.any(String, Symbol),
       message: String,
-      in: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
-      within: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
+      in: InWithinType,
+      within: InWithinType,
       if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       on: T.any(Symbol, String),

--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -176,8 +176,8 @@ module ActiveModel::Validations::HelperMethods
     params(
       attr_names: T.any(String, Symbol),
       message: String,
-      in: T.nilable(T::Range[Integer]),
-      within: T.nilable(T::Range[Integer]),
+      in: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
+      within: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
       if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       on: T.any(Symbol, String),
@@ -232,8 +232,8 @@ module ActiveModel::Validations::HelperMethods
     params(
       attr_names: T.any(String, Symbol),
       message: String,
-      in: T.nilable(T::Range[Integer]),
-      within: T.nilable(T::Range[Integer]),
+      in: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
+      within: T.nilable(T.any(T::Array[T.any(String, Symbol)], T::Range[Integer])),
       if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
       on: T.any(Symbol, String),

--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -97,3 +97,268 @@ class ActiveModel::Type::Boolean
   sig { params(arg0: T.untyped).returns(T.nilable(T::Boolean))}
   def cast(arg0); end
 end
+
+module ActiveModel::Validations::HelperMethods
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_absence_of(
+    *attr_names,
+    message: 'must be blank', 
+    if: nil, 
+    unless: :_, 
+    on: :_, 
+    allow_nil: false, 
+    allow_blank: false, 
+    strict: false
+  ); end
+
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      accept: T.untyped,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_acceptance_of(
+    *attr_names,
+    message: 'must be accepted', 
+    accept: ['1', true], 
+    if: nil, 
+    unless: :_, 
+    on: :_, 
+    allow_nil: false, 
+    allow_blank: false,
+    strict: false
+  ); end
+
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      case_sensitive: T::Boolean,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_confirmation_of(
+    *attr_names,
+    message: "doesn't match %{translated_attribute_name}",
+    case_sensitive: true,
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
+
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      in: T.nilable(T::Range[Integer]),
+      within: T.nilable(T::Range[Integer]),
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_exclusion_of(
+    *attr_names,
+    message: 'is reserved',
+    in: nil,
+    within: nil,
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
+
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      with: T.untyped,
+      without: T.untyped,
+      multiline: T.untyped,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_format_of(
+    *attr_names,
+    message: 'is invalid',
+    with: nil,
+    without: nil,
+    multiline: nil,
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
+
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      in: T.nilable(T::Range[Integer]),
+      within: T.nilable(T::Range[Integer]),
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_inclusion_of(
+    *attr_names,
+    message: 'is not included in the list',
+    in: nil,
+    within: nil,
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
+
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: T.nilable(String),
+      minimum: T.nilable(Integer),
+      maximum: T.nilable(Integer),
+      is: T.nilable(Integer),
+      within: T.nilable(T::Range[Integer]),
+      in: T.nilable(T::Range[Integer]),
+      too_long: String,
+      too_short: String,
+      wrong_length: String,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_length_of(
+    *attr_names,
+    message: nil,
+    minimum: nil,
+    maximum: nil,
+    is: nil,
+    within: nil,
+    in: nil,
+    too_long: 'is too long (maximum is %{count} characters)',
+    too_short: 'is too short (minimum is %{count} characters)',
+    wrong_length: 'is the wrong length (should be %{count} characters)',
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
+  
+  alias_method :validates_size_of, :validates_length_of
+
+  # Create a type alias so we don't have to repeat this long type signature 6 times.
+  NumberComparatorType = T.type_alias(T.nilable(T.any(Integer, Float, T.proc.params(arg0: T.untyped).returns(T::Boolean), Symbol)))
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      only_integer: T::Boolean,
+      greater_than: NumberComparatorType,
+      greater_than_or_equal_to: NumberComparatorType,
+      equal_to: NumberComparatorType,
+      less_than: NumberComparatorType,
+      less_than_or_equal_to: NumberComparatorType,
+      other_than: NumberComparatorType,
+      odd: T::Boolean,
+      even: T::Boolean,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_numericality_of(
+    *attr_names,
+    message: 'is not a number',
+    only_integer: false,
+    greater_than: nil,
+    greater_than_or_equal_to: nil,
+    equal_to: nil,
+    less_than: nil,
+    less_than_or_equal_to: nil,
+    other_than: nil,
+    odd: false,
+    even: false,
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
+
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: String,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_presence_of(
+    *attr_names,
+    message: "can't be blank",
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
+end


### PR DESCRIPTION
https://api.rubyonrails.org/classes/ActiveModel/Validations/HelperMethods.html

These are used like so:

```ruby
validates_absence_of :first_name
validates_acceptance_of :eula, message: 'must be abided'
validates_confirmation_of :email_address, message: 'should match confirmation'
validates_exclusion_of :username, in: %w( admin superuser ), message: "You don't belong here"
validates_exclusion_of :age, in: 30..60, message: 'This site is only for under 30 and over 60'
validates_exclusion_of :format, in: %w( mov avi ), message: "extension %{value} is not allowed"
validates_exclusion_of :password, in: ->(person) { [person.username, person.first_name] },
                       message: 'should not be the same as your username or first name'
validates_exclusion_of :karma, in: :reserved_karmas
validates_length_of :phone, in: 7..32, allow_blank: true
validates_inclusion_of :gender, in: %w( m f )
validates_inclusion_of :age, in: 0..99
validates_inclusion_of :format, in: %w( jpg gif png ), message: "extension %{value} is not included in the list"
validates_inclusion_of :states, in: ->(person) { STATES[person.country] }
validates_inclusion_of :karma, in: :available_karmas
validates_format_of :screen_name, with: ->(person) { person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\z/i : /\A[a-z][a-z0-9_\-]*\z/i }
validates_format_of :email, without: /NOSPAM/
validates_numericality_of :width, less_than: ->(person) { person.height }
validates_numericality_of :width, greater_than: :minimum_weight
validates_presence_of :first_name
```

I based some of the types on the parameter typings in `validates`.