### PR TITLE
Fix parameter ordering in rbi files.

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -165,12 +165,12 @@ module ActiveRecord::Associations::ClassMethods
       autosave: T.nilable(T::Boolean),
       before_add: T.nilable(T.any(Symbol, String, T.proc.void)),
       before_remove: T.nilable(T.any(Symbol, String, T.proc.void)),
-      blk: T.nilable(T.proc.void),
       class_name: T.nilable(T.any(Symbol, String)),
       extend: T.nilable(T.any(Module, T::Array[Module])),
       foreign_key: T.nilable(T.any(Symbol, String)),
       join_table: T.nilable(T.any(Symbol, String)),
       validate: T.nilable(T::Boolean),
+      blk: T.nilable(T.proc.void)
     ).void
   end
   def has_and_belongs_to_many(

--- a/lib/grape/all/grape.rbi
+++ b/lib/grape/all/grape.rbi
@@ -37,14 +37,14 @@ class Grape::API
     params(
       name: Symbol,
       type: T.untyped,
+      desc: String,
       allow_blank: T::Boolean,
       values: T::Array[T.untyped],
       date_parameter: T::Boolean,
       positive_number: T::Boolean,
       acord130_question_number: T::Boolean,
       percent_parameter: T::Boolean,
-      id_for_entity_type: T.untyped,
-      desc: String
+      id_for_entity_type: T.untyped
     ).void
   end
   def self.optional(

--- a/lib/state_machines/all/state_machines.rbi
+++ b/lib/state_machines/all/state_machines.rbi
@@ -32,8 +32,8 @@ class StateMachines::StateContext
     params(
       methods: Symbol,
       from: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
-      to: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
       on: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
+      to: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
       do: T.any(Symbol, T.proc.params(arg0: T.untyped).void),
       blk: T.any(NilClass, T.proc.params(arg0: T.untyped).void),
     ).void
@@ -44,8 +44,8 @@ class StateMachines::StateContext
     params(
       methods: Symbol,
       from: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
-      to: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
       on: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
+      to: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
       do: T.any(Symbol, T.proc.params(arg0: T.untyped).void),
       blk: T.any(NilClass, T.proc.params(arg0: T.untyped).void),
     ).void


### PR DESCRIPTION
Because of https://github.com/sorbet/sorbet/pull/1273, `ruby .ci/run.rb` was failing. This fixes that.