### PR TITLE
Add types for activerecord-safer_migrations

### DIFF
--- a/lib/activerecord-safer_migrations/<=2/activerecord-safer_migrations.rbi
+++ b/lib/activerecord-safer_migrations/<=2/activerecord-safer_migrations.rbi
@@ -1,0 +1,33 @@
+# typed: strong
+
+module ActiveRecord::SaferMigrations
+  sig { returns(Integer) }
+  def self.default_lock_timeout; end
+
+  sig { params(timeout_ms: Integer).returns(Integer) }
+  def self.default_lock_timeout=(timeout_ms); end
+
+  sig { returns(Integer) }
+  def self.default_statement_timeout; end
+
+  sig { params(timeout_ms: Integer).returns(Integer) }
+  def self.default_statement_timeout=(timeout_ms); end
+end
+
+module ActiveRecord::SaferMigrations::Migration::ClassMethods
+  sig { void }
+  def disable_lock_timeout!; end
+
+  sig { void }
+  def disable_statement_timeout!; end
+
+  sig { params(timeout_ms: Integer).void }
+  def set_lock_timeout(timeout_ms); end
+
+  sig { params(timeout_ms: Integer).void }
+  def set_statement_timeout(timeout_ms); end
+end
+
+class ActiveRecord::Migration
+  extend ActiveRecord::SaferMigrations::Migration::ClassMethods
+end


### PR DESCRIPTION
Add types for `activerecord-safer_migrations` gem

- https://github.com/gocardless/activerecord-safer_migrations
- https://rubygems.org/gems/activerecord-safer_migrations

These are compatible with both v2 (current) and v1.