### PR TITLE
Add #request method for Rails controllers

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -1,5 +1,16 @@
 # typed: strong
 
+class ActionController::Base < ActionController::Metal
+end
+
+class ActionController::Metal
+  sig {returns(ActionDispatch::Request)}
+  def request(); end
+end
+
+class ActionDispatch::Request
+end
+
 class ActionDispatch::Routing::RouteSet
   sig {params(blk: T.proc.bind(ActionDispatch::Routing::Mapper).void).void}
   def draw(&blk); end


### PR DESCRIPTION
This is a first step in filling out the ActionController sigs for Rails. Technically the `#request` method is nillable. In practice I don't think this is intended to be the case (at least the docs indicate that a request object is returned). That said, it's entirely possible to instantiate a controller with a `nil` request outside of a normal Rails request:

```
::AplicationController.new.request # => nil
```

This results in the need to use `T.nilable(ActionDispatch::Request)` in type signatures or `T.must` at the call-site to avoid nils. Some guidance on if I can omit the `T.nilable` would be much appreciated.