### PR TITLE
Add ActiveSupport Array methods from Rails 6.

### DIFF
--- a/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
+++ b/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
@@ -6,7 +6,7 @@ class Array
 
   sig do
     params(
-      blk: T.nilable(T.proc.params(arg0: Elem).returns(Elem))
+      blk: T.nilable(T.proc.params(arg0: Elem).void)
     ).returns(T.any(T::Array[Elem], T::Enumerable))
   end
   def extract!(&blk); end

--- a/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
+++ b/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
@@ -7,7 +7,7 @@ class Array
   sig do
     params(
       blk: T.nilable(T.proc.params(arg0: Elem).void)
-    ).returns(T.any(T::Array[Elem], T::Enumerable))
+    ).returns(T.any(T::Array[Elem], T::Enumerable[Elem]))
   end
   def extract!(&blk); end
 

--- a/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
+++ b/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
@@ -1,0 +1,16 @@
+# typed: strong
+
+class Array
+  sig { params(elements: T.untyped).returns(T::Array[T.untyped]) }
+  def excluding(*elements); end
+
+  sig do
+    params(
+      blk: T.nilable(T.proc.params(arg0: Elem).returns(Elem))
+    ).returns(T.any(T::Array[Elem], T::Enumerable))
+  end
+  def extract!(&blk); end
+
+  sig { params(elements: T.untyped).returns(T::Array[T.untyped]) }
+  def including(*elements); end
+end

--- a/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
+++ b/lib/activesupport/>=6.0.0.rc1/activesupport.rbi
@@ -6,7 +6,7 @@ class Array
 
   sig do
     params(
-      blk: T.nilable(T.proc.params(arg0: Elem).void)
+      blk: T.nilable(T.proc.params(arg0: Elem).returns(T::Boolean))
     ).returns(T.any(T::Array[Elem], T::Enumerable[Elem]))
   end
   def extract!(&blk); end


### PR DESCRIPTION
There are three new Array methods in Rails 6.

Here's the docs for `extract!`: https://edgeapi.rubyonrails.org/classes/Array.html#method-i-extract-21