### PR TITLE
Update the ActiveRecord #update method to allow an array of hashes.

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -736,10 +736,14 @@ module ActiveRecord::Persistence::ClassMethods
   sig { params(attributes: T.untyped, column_types: T::Hash[T.untyped, T.untyped], blk: T.proc.void).returns(T.untyped) }
   def instantiate(attributes, column_types = {}, &blk); end
 
+  # The 'attributes' parameter can take either a hash or an array of hashes.
   sig do
     params(
       id: T.any(T.untyped, T::Array[T.untyped], Symbol),
-      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+      attributes: T.any(
+        T::Hash[T.any(Symbol, String), T.untyped],
+        T::Array[T::Hash[T.any(Symbol, String), T.untyped]]
+      )
     ).returns(T.any(T::Array[T.untyped], T.untyped))
   end
   def update(id = :all, attributes); end


### PR DESCRIPTION
This capability is mentioned briefly in [the docs](https://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-update), and I noticed that the existing signature wasn't accurate yesterday while implementing a 'bulk update' feature in my Rails app.

Essentially, if you want to update multiple records at once (`update_all` is sometimes insufficient, since it doesn't run validations/callbacks), you can pass multiple record ids to the `#update` method. Then, you also need to pass the attributes for each record.

The example in the docs looks like this:

```ruby
people = { 1 => { "first_name" => "David" }, 2 => { "first_name" => "Jeremy" } }
Person.update(people.keys, people.values)
```

To simplify that code, it's actually using the method like this:
```ruby
Person.update(
  [1, 2],
  [
    { "first_name" => "David" },
    { "first_name" => "Jeremy" }
  ]
)
```

And of course, the 'normal' single-record usage would be:

```ruby
Person.update(15, user_name: "Samuel", group: "expert")
```

So this supports both cases.