### PR TITLE
Replace aliased methods with actual methods.

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -307,7 +307,45 @@ module ActiveModel::Validations::HelperMethods
     strict: false
   ); end
   
-  alias_method :validates_size_of, :validates_length_of
+  # validates_size_of is an alias of validates_length_of
+  sig do
+    params(
+      attr_names: T.any(String, Symbol),
+      message: T.nilable(String),
+      minimum: T.nilable(Integer),
+      maximum: T.nilable(Integer),
+      is: T.nilable(Integer),
+      within: T.nilable(T::Range[Integer]),
+      in: T.nilable(T::Range[Integer]),
+      too_long: String,
+      too_short: String,
+      wrong_length: String,
+      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+      on: T.any(Symbol, String),
+      allow_nil: T::Boolean,
+      allow_blank: T::Boolean,
+      strict: T::Boolean
+    ).void
+  end
+  def validates_size_of(
+    *attr_names,
+    message: nil,
+    minimum: nil,
+    maximum: nil,
+    is: nil,
+    within: nil,
+    in: nil,
+    too_long: 'is too long (maximum is %{count} characters)',
+    too_short: 'is too short (minimum is %{count} characters)',
+    wrong_length: 'is the wrong length (should be %{count} characters)',
+    if: nil,
+    unless: :_,
+    on: :_,
+    allow_nil: false,
+    allow_blank: false,
+    strict: false
+  ); end
 
   # Create a type alias so we don't have to repeat this long type signature 6 times.
   NumberComparatorType = T.type_alias(T.nilable(T.any(Integer, Float, T.proc.params(arg0: T.untyped).returns(T::Boolean), Symbol)))

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -643,6 +643,14 @@ module ActiveRecord::Persistence
   end
   def update!(attributes); end
 
+  # update_attributes! is an alias of update!
+  sig do
+    params(
+      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+    ).returns(TrueClass)
+  end
+  def update_attributes!(attributes); end
+
   sig do
     params(
       attributes: T::Hash[T.any(Symbol, String), T.untyped]
@@ -650,8 +658,13 @@ module ActiveRecord::Persistence
   end
   def update(attributes); end
 
-  alias update_attributes update
-  alias update_attributes! update!
+  # update_attributes is an alias of update
+  sig do
+    params(
+      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+    ).returns(T::Boolean)
+  end
+  def update_attributes(attributes); end
 end
 
 module ActiveRecord::Persistence::ClassMethods

--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -131,7 +131,9 @@ class String
   sig { returns(String) }
   def demodulize; end
 
-  alias_method :ends_with?, :end_with?
+  # ends_with? is an alias of the core method 'end_with?'
+  sig { params(arg0: String).returns(T::Boolean) }
+  def ends_with?(*arg0); end
 
   sig { params(string: String).returns(T::Boolean) }
   def exclude?(string); end
@@ -196,7 +198,9 @@ class String
   sig { returns(String) }
   def squish; end
 
-  alias_method :starts_with?, :start_with?
+  # starts_with? is an alias of the core method 'start_with?''
+  sig { params(arg0: String).returns(T::Boolean) }
+  def starts_with?(*arg0); end
 
   sig { returns(String) }
   def strip_heredoc; end
@@ -290,7 +294,9 @@ class Array
   sig { params(position: Integer).returns(T::Array[T.untyped]) }
   def to(position); end
 
-  alias_method :to_default_s, :to_s
+  # to_default_s is an alias of the core method 'to_s'
+  sig {returns(String)}
+  def to_defaul_s; end
 
   sig { params(format: Symbol).returns(String) }
   def to_formatted_s(format = :default); end


### PR DESCRIPTION
Sorbet was giving method-redefinition errors about these when they were used with the actual gems, so this replaces them with the full methods.