### PR TITLE
Allow `path => controller#action` in Routes

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -111,7 +111,7 @@ module ActionDispatch::Routing::Mapper::HttpHelpers
   # ActionDispatch::Routing::Mapper::Resources#match
   sig do
     params(
-      name: T.any(String, Symbol),
+      name: T.any(String, Symbol, T::Hash[String, String]),
       controller: T.nilable(T.any(String, Symbol)),
       action: T.nilable(T.any(String, Symbol)),
       param: T.nilable(Symbol),
@@ -148,7 +148,7 @@ module ActionDispatch::Routing::Mapper::HttpHelpers
 
   sig do
     params(
-      name: T.any(String, Symbol),
+      name: T.any(String, Symbol, T::Hash[String, String]),
       controller: T.nilable(T.any(String, Symbol)),
       action: T.nilable(T.any(String, Symbol)),
       param: T.nilable(Symbol),
@@ -185,7 +185,7 @@ module ActionDispatch::Routing::Mapper::HttpHelpers
 
   sig do
     params(
-      name: T.any(String, Symbol),
+      name: T.any(String, Symbol, T::Hash[String, String]),
       controller: T.nilable(T.any(String, Symbol)),
       action: T.nilable(T.any(String, Symbol)),
       param: T.nilable(Symbol),
@@ -222,7 +222,7 @@ module ActionDispatch::Routing::Mapper::HttpHelpers
 
   sig do
     params(
-      name: T.any(String, Symbol),
+      name: T.any(String, Symbol, T::Hash[String, String]),
       controller: T.nilable(T.any(String, Symbol)),
       action: T.nilable(T.any(String, Symbol)),
       param: T.nilable(Symbol),
@@ -259,7 +259,7 @@ module ActionDispatch::Routing::Mapper::HttpHelpers
 
   sig do
     params(
-      name: T.any(String, Symbol),
+      name: T.any(String, Symbol, T::Hash[String, String]),
       controller: T.nilable(T.any(String, Symbol)),
       action: T.nilable(T.any(String, Symbol)),
       param: T.nilable(Symbol),
@@ -304,7 +304,7 @@ module ActionDispatch::Routing::Mapper::Resources
 
   sig do
     params(
-      name: T.any(String, Symbol),
+      name: T.any(String, Symbol, T::Hash[String, String]),
       controller: T.nilable(T.any(String, Symbol)),
       action: T.nilable(T.any(String, Symbol)),
       param: T.nilable(Symbol),

--- a/lib/actionpack/test/actionpack_test.rb
+++ b/lib/actionpack/test/actionpack_test.rb
@@ -35,4 +35,11 @@ module ActionPackTest
   end
 
   get '/about', to: 'static_pages#about'
+
+  delete 'about' => 'static_pages#about'
+  get 'about' => 'static_pages#about'
+  match 'about' => 'static_pages#about'
+  patch 'about' => 'static_pages#about'
+  post 'about' => 'static_pages#about'
+  put 'about' => 'static_pages#about'
 end


### PR DESCRIPTION
The `'path' => 'controller#action'` is a supported short-hand syntax
for Rails routes as documented [here][1]. The current type is too
restrictive and does not support this valid syntax. This change modifies
the first argument type so that it supports the Hash syntax.

[1]: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/mapper.rb#L1605