### PR TITLE
Add test files for actionpack, activemodel, activerecord, and activesupport

### DIFF
--- a/.ci/run.rb
+++ b/.ci/run.rb
@@ -3,7 +3,7 @@
 # Exclude files if necessary here.
 exclude = []
 
-file_paths = Dir.glob("**/*.rbi").select{|p| !exclude.include?(p)}.map{|p| "\"#{p}\""}.join(' ')
+file_paths = Dir.glob("**/*.rb{i,}").select{|p| !exclude.include?(p)}.map{|p| "\"#{p}\""}.join(' ')
 
 srb_cmd = 'tc'
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To add `.rbi` files for a particular gem:
 1. Add a subdirectory to `lib` with the same name as the gem.
 2. Add a subdirectory to the gem subdirectory with a name matching the version you are adding signatures to. (See [Version Constraints](#version-constraints) below for a more thorough explanation)
 3. Create the `json-schema.rbi` file in the version directory you've chosen.
+4. Optional, but encouraged: Add a test file in `lib/gem_name/test/gem_name_test.rb`. See the [Testing section](#testing) for details.
 
 ### Version Constraints
 
@@ -58,6 +59,25 @@ Once you've made any changes you wanted, you can copy the contents of the file i
 Right now, there's no standard formatting for the `.rbi` files in this repository, but you should try to at least keep it consistent within a given file.
 
 You can make sure your `.rbi` passes typechecking by installing the latest version of Sorbet (`gem install sorbet`) and running `ruby .ci/run.rb` in this repository.
+
+### Tests
+
+There's basic support in sorbet-typed for testing of type signatures. Right now, you can only have valid usage of your methods in tests. This can be used to ensure the type signatures aren't causing typecheck failures on valid code. The test file for a gem should be placed at `lib/gem_name/test/gem_name_test.rb`.
+
+For example, if you wanted to test the signatures for the `validates` method in the Rails gem `activemodel`, you could create a file at `lib/activemodel/test/activemodel_test.rb` like this:
+
+```ruby
+# typed: true
+
+module ActiveModelTest
+  extend ActiveModel::Validations::ClassMethods
+
+  validates :name, length: { minimum: 2 }
+  validates :age, numericality: true, on: :update
+end
+```
+
+This tests a few of the parameters available on the `validates` method based on existing code from the ActiveModel documentation or active codebases using the gem.
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ end
 
 This tests a few of the parameters available on the `validates` method based on existing code from the ActiveModel documentation or active codebases using the gem.
 
+The tests can be run locally by installing Sorbet with `gem install sorbet` and then running `ruby .ci/run.rb`.
+
 # Contributors
 
 This repository was originally written by the fine folks at

--- a/lib/actionpack/test/actionpack_test.rb
+++ b/lib/actionpack/test/actionpack_test.rb
@@ -1,0 +1,39 @@
+# typed: true
+
+module ActionPackTest
+  extend ActionDispatch::Routing::Mapper::HttpHelpers
+  extend ActionDispatch::Routing::Mapper::Resources
+
+  root 'home#index'
+  get 'home/index'
+
+  # This is meant to fail, to show that this works.
+  resources :games, invalid: 'test' do
+    get :search, on: :collection
+  end
+
+  resources :game_purchases, except: [:edit, :new] do
+    post :bulk_update, on: :collection
+  end
+
+  resources :users do
+    get :index, on: :collection
+    get :statistics, on: :member
+    get '/compare/:user_id...:other_user_id', as: :compare, action: :compare, on: :collection
+  end
+
+  resources :platforms do
+    get :search, on: :collection
+  end
+
+  namespace :search do
+    get :index, as: '/', path: '/'
+  end
+
+  namespace :settings do
+    get :profile, as: '/', path: '/'
+    get :account
+  end
+
+  get '/about', to: 'static_pages#about'
+end

--- a/lib/actionpack/test/actionpack_test.rb
+++ b/lib/actionpack/test/actionpack_test.rb
@@ -7,8 +7,7 @@ module ActionPackTest
   root 'home#index'
   get 'home/index'
 
-  # This is meant to fail, to show that this works.
-  resources :games, invalid: 'test' do
+  resources :games do
     get :search, on: :collection
   end
 

--- a/lib/activemodel/test/activemodel_test.rb
+++ b/lib/activemodel/test/activemodel_test.rb
@@ -2,6 +2,49 @@
 
 module ActiveModelTest
   extend ActiveModel::Validations::HelperMethods
+  extend ActiveModel::Validations::ClassMethods
+
+  validates :bio, length: { maximum: 1000,
+    too_long: "%{count} characters is the maximum allowed" }
+
+  validates :name, length: { minimum: 2 }
+  validates :bio, length: { maximum: 500 }
+  validates :password, length: { in: 6..20 }
+  validates :registration_number, length: { is: 6 }
+
+  validates :points, numericality: true
+  validates :games_played, numericality: { only_integer: true }
+
+  validates :name, :login, :email, presence: true
+  validates :order, presence: true
+  
+  validates :name, :login, :email, absence: true
+
+  validates :email, uniqueness: true
+  validates :name, uniqueness: { scope: :year,
+    message: "should happen once per year" }
+
+  validates :boolean_field_name, inclusion: { in: [true, false] }
+  validates :boolean_field_name, exclusion: { in: [nil] }
+  validates :name, uniqueness: { case_sensitive: false }
+
+  validates :title, length: { is: 5 }, allow_blank: true
+  validates :size, inclusion: { in: %w(small medium large),
+    message: "%{value} is not a valid size" }, allow_nil: true
+
+  validates :age, numericality: { message: "%{value} seems wrong" }
+
+  validates :age, numericality: true, on: :update
+  
+  
+  validates :token, presence: true, uniqueness: true, strict: TokenGenerationException
+  
+  validates :card_number, presence: true, if: :paid_with_card?
+
+  # TODO: These are valid but currently fail typechecking.
+  # validates :password, confirmation: true, unless: Proc.new { |a| a.password.blank? }
+  # validates :name, presence: { strict: true }
+  # validates :password, confirmation: true, unless: -> { true }
 
   # Test a variety of uses for the ActiveModel validation methods.
   validates_absence_of :first_name

--- a/lib/activemodel/test/activemodel_test.rb
+++ b/lib/activemodel/test/activemodel_test.rb
@@ -1,0 +1,27 @@
+# typed: true
+
+module ActiveModelTest
+  extend ActiveModel::Validations::HelperMethods
+
+  # Test a variety of uses for the ActiveModel validation methods.
+  validates_absence_of :first_name
+  validates_acceptance_of :eula, message: 'must be abided'
+  validates_confirmation_of :email_address, message: 'should match confirmation'
+  validates_exclusion_of :username, in: %w( admin superuser ), message: "You don't belong here"
+  validates_exclusion_of :age, in: 30..60, message: 'This site is only for under 30 and over 60'
+  validates_exclusion_of :format, in: %w( mov avi ), message: "extension %{value} is not allowed"
+  validates_exclusion_of :password, in: ->(person) { [person.username, person.first_name] },
+                        message: 'should not be the same as your username or first name'
+  validates_exclusion_of :karma, in: :reserved_karmas
+  validates_length_of :phone, in: 7..32, allow_blank: true
+  validates_inclusion_of :gender, in: %w( m f )
+  validates_inclusion_of :age, in: 0..99
+  validates_inclusion_of :format, in: %w( jpg gif png ), message: "extension %{value} is not included in the list"
+  validates_inclusion_of :states, in: ->(person) { STATES[person.country] }
+  validates_inclusion_of :karma, in: :available_karmas
+  validates_format_of :screen_name, with: ->(person) { person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\z/i : /\A[a-z][a-z0-9_\-]*\z/i }
+  validates_format_of :email, without: /NOSPAM/
+  validates_numericality_of :width, less_than: ->(person) { person.height }
+  validates_numericality_of :width, greater_than: :minimum_weight
+  validates_presence_of :first_name
+end

--- a/lib/activemodel/test/activemodel_test.rb
+++ b/lib/activemodel/test/activemodel_test.rb
@@ -35,8 +35,7 @@ module ActiveModelTest
   validates :age, numericality: { message: "%{value} seems wrong" }
 
   validates :age, numericality: true, on: :update
-  
-  
+
   validates :token, presence: true, uniqueness: true, strict: TokenGenerationException
   
   validates :card_number, presence: true, if: :paid_with_card?

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -131,7 +131,7 @@ module ActiveRecord::Associations::ClassMethods
       polymorphic: T.nilable(T::Boolean),
       primary_key: T.nilable(T.any(Symbol, String)),
       required: T.nilable(T::Boolean),
-      touch: T.nilable(T::Boolean),
+      touch: T.nilable(T.any(T::Boolean, Symbol)),
       validate: T.nilable(T::Boolean),
       default: T.nilable(T.proc.returns(T.untyped))
     ).void

--- a/lib/activerecord/test/activerecord_test.rb
+++ b/lib/activerecord/test/activerecord_test.rb
@@ -1,0 +1,75 @@
+# typed: true
+
+# This code is all taken from the ActiveRecord Migrations guide.
+# https://guides.rubyonrails.org/active_record_migrations.html
+# This tests as many valid migrations methods as it can.
+class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
+  def change
+    create_table :products do |t|
+      t.string :name
+      t.text :description
+ 
+      t.timestamps
+    end
+
+    add_column :products, :part_number, :string
+    rename_column :users, :email, :email_address
+    remove_column :products, :part_number, :string
+
+    add_index :products, :part_number
+    add_reference :products, :user, foreign_key: true
+
+    add_column :products, :price, :decimal, precision: 5, scale: 2
+    add_reference :products, :supplier, polymorphic: true
+
+    create_join_table :products, :categories, column_options: { null: true }
+    create_join_table :products, :categories, table_name: :categorization
+
+    create_join_table :products, :categories do |t|
+      t.index :product_id
+      t.index :category_id
+    end
+
+    change_table :products do |t|
+      t.remove :description, :name
+      t.string :part_number
+      t.index :part_number
+      t.rename :upccode, :upc_code
+    end
+
+    change_column :products, :part_number, :text
+
+    change_column_null :products, :name, false
+    change_column_default :products, :approved, from: true, to: false
+
+    add_foreign_key :articles, :authors
+    remove_foreign_key :accounts, :branches
+    remove_foreign_key :accounts, column: :owner_id
+    remove_foreign_key :accounts, name: :special_fk_name
+    
+    execute <<-SQL
+      ALTER TABLE distributors
+        DROP CONSTRAINT zipchk
+    SQL
+
+    drop_table :distributors
+
+    suppress_messages do
+      create_table :products do |t|
+        t.string :name
+        t.text :description
+        t.timestamps
+      end
+    end
+ 
+    say "Created a table"
+ 
+    suppress_messages { add_index :products, :name }
+    say "and an index!", true
+ 
+    say_with_time 'Waiting for a while' do
+      sleep 10
+      250
+    end
+  end
+end 

--- a/lib/activerecord/test/activerecord_test.rb
+++ b/lib/activerecord/test/activerecord_test.rb
@@ -72,4 +72,40 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
       250
     end
   end
-end 
+end
+
+module ActiveRecordAssociationsTest
+  extend ActiveRecord::Associations::ClassMethods
+
+  has_many :people
+  has_many :people, -> { true }, class_name: "Person"
+  has_many :tracks, dependent: :destroy
+  has_many :comments, dependent: :nullify
+  has_many :tags, as: :taggable
+  has_many :subscribers, through: :subscriptions, source: :user
+
+  has_one :credit_card
+  has_one :credit_card, dependent: :destroy
+  has_one :credit_card, dependent: :nullify
+  has_one :last_comment, class_name: "Comment"
+  has_one :attachment, as: :attachable
+  has_one :club, through: :membership
+  has_one :primary_address, -> { true }, through: :addressables, source: :addressable
+  has_one :credit_card, required: true
+
+  has_and_belongs_to_many :projects
+  has_and_belongs_to_many :projects, -> { true }
+  has_and_belongs_to_many :nations, class_name: "Country"
+  has_and_belongs_to_many :categories, join_table: "prods_cats"
+
+  belongs_to :firm, foreign_key: "client_of"
+  belongs_to :person, primary_key: "name", foreign_key: "person_name"
+  belongs_to :author, class_name: "Person", foreign_key: "author_id"
+  belongs_to :attachable, polymorphic: true
+  belongs_to :post, counter_cache: true
+  belongs_to :comment, touch: true
+  belongs_to :company, touch: :employees_last_updated_at
+  belongs_to :comment, autosave: true, required: true
+  belongs_to :user, optional: true
+  belongs_to :account, default: -> { true }
+end

--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -345,10 +345,10 @@ module ActiveSupport::NumberHelper
       locale: Symbol,
       delimiter: String,
       separator: String,
-      delimiter_patter: T.nilable(Regexp)
+      delimiter_pattern: T.nilable(Regexp)
     ).returns(String)
   end
-  def number_to_delimited(number, locale: :en, delimiter: ",", separator: ".", delimiter_patter: nil); end
+  def number_to_delimited(number, locale: :en, delimiter: ",", separator: ".", delimiter_pattern: nil); end
 
   sig do
     params(
@@ -359,7 +359,7 @@ module ActiveSupport::NumberHelper
       separator: String,
       delimiter: String,
       strip_insignificant_zeros: T::Boolean,
-      units: T.any(T::Hash[T.untyped, T.untyped], String),
+      units: T.any(T::Hash[T.untyped, T.untyped], String, Symbol),
       format: String
     ).returns(String)
   end
@@ -387,7 +387,7 @@ module ActiveSupport::NumberHelper
       separator: String,
       delimiter: String,
       strip_insignificant_zeros: T::Boolean,
-      format: Symbol
+      format: String
     ).returns(String)
   end
   def number_to_percentage(number, locale: :en, precision: 3, significant: false, separator: ".", delimiter: "", strip_insignificant_zeros: false, format: "%n%"); end

--- a/lib/activesupport/test/activesupport_test.rb
+++ b/lib/activesupport/test/activesupport_test.rb
@@ -1,0 +1,57 @@
+# typed: true
+
+module ActiveSupportNumberHelperTest
+  extend ActiveSupport::NumberHelper
+
+  number_to_currency(1234567890.50)
+  number_to_currency(1234567890.506, precision: 3)
+  number_to_currency(1234567890.506, locale: :fr)
+  number_to_currency(-1234567890.50, negative_format: '(%u%n)')
+  number_to_currency(1234567890.50, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
+
+  number_to_delimited(12345678)
+  number_to_delimited('123456')
+  number_to_delimited(12345678.05)
+  number_to_delimited(12345678.05, separator: ' ')
+  number_to_delimited(12345678.05, locale: :fr)
+  number_to_delimited('112a')
+  number_to_delimited(98765432.98, delimiter: ' ', separator: ',')
+  number_to_delimited("123456.78", delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/)
+
+  number_to_human(123)
+  number_to_human(1234567890123456789)
+  number_to_human(1234567, precision: 4, significant: false)
+  number_to_human(1234567, precision: 1, separator: ',', significant: false)
+  number_to_human(543934, units: :distance)
+  number_to_human(343, units: :distance, precision: 1)
+  number_to_human(0.34, units: :distance)
+
+  number_to_human_size(123)
+  number_to_human_size(1234567, precision: 2)
+  number_to_human_size(1234567, precision: 2, separator: ',')
+
+  number_to_percentage(100)
+  number_to_percentage('98')
+  number_to_percentage(100, precision: 0)
+  number_to_percentage(1000, delimiter: '.', separator: ',')
+  number_to_percentage(302.24398923423, precision: 5)
+  number_to_percentage(1000, locale: :fr)
+  number_to_percentage(1000, precision: nil)
+  number_to_percentage('98a')
+  number_to_percentage(100, format: '%n  %')
+
+  number_to_phone(5551234) 
+  number_to_phone('5551234')
+  number_to_phone(1235551234, area_code: true, extension: 555)
+  number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: '.')
+  number_to_phone(75561234567, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true)
+
+  number_to_rounded(111.2345)
+  number_to_rounded(111.2345, precision: 2)
+  number_to_rounded(111.2345, precision: 1, significant: true)
+  number_to_rounded(13, precision: 5, significant: true)
+  number_to_rounded(13, precision: nil)
+  number_to_rounded(111.234, locale: :fr)
+  number_to_rounded(13, precision: 5, significant: true, strip_insignificant_zeros: true)
+  number_to_rounded(1111.2345, precision: 2, separator: ',', delimiter: '.')
+end


### PR DESCRIPTION
I have no idea what this does to sorbet if this is merged and you try to update sorbet-typed.

I've included an intentionally failing method to show that this is working. However, it only allows files that have no type errors, there's no way to test that sorbet catches incorrect code.

This is a simplified version of my `routes.rb` file that I showed in #95.

The idea to do this was started by #42 and re-upped in #102 by @panthomakos.

cc: @DarkDimius @jez I know this isn't the test harness you wanted, and I'd still like to get that eventually, but I'm curious if you think this solution would be workable? Do you see any significant flaws with this approach?