### PR TITLE
ActiveRecord update/update_attributes methods accept ActionController::Parameters

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -638,7 +638,10 @@ module ActiveRecord::Persistence
 
   sig do
     params(
-      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+      attributes: T.any(
+        T::Hash[T.any(Symbol, String), T.untyped],
+        ActionController::Parameters
+      )
     ).returns(TrueClass)
   end
   def update!(attributes); end
@@ -646,14 +649,20 @@ module ActiveRecord::Persistence
   # update_attributes! is an alias of update!
   sig do
     params(
-      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+      attributes: T.any(
+        T::Hash[T.any(Symbol, String), T.untyped],
+        ActionController::Parameters
+      )
     ).returns(TrueClass)
   end
   def update_attributes!(attributes); end
 
   sig do
     params(
-      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+      attributes: T.any(
+        T::Hash[T.any(Symbol, String), T.untyped],
+        ActionController::Parameters
+      )
     ).returns(T::Boolean)
   end
   def update(attributes); end
@@ -661,7 +670,10 @@ module ActiveRecord::Persistence
   # update_attributes is an alias of update
   sig do
     params(
-      attributes: T::Hash[T.any(Symbol, String), T.untyped]
+      attributes: T.any(
+        T::Hash[T.any(Symbol, String), T.untyped],
+        ActionController::Parameters
+      )
     ).returns(T::Boolean)
   end
   def update_attributes(attributes); end


### PR DESCRIPTION
It's somewhat common to have code like this in a Rails controller:
```ruby
class GenresController < ApplicationController
  def update
    @genre = Genre.find(params[:id])
    authorize @genre

    if @genre.update(genre_params)
      redirect_to @genre, success: "#{@genre.name} was successfully updated."
    else
      flash.now[:error] = "Unable to update genre."
      render :edit
    end
  end
  
  private

  def genre_params
    params.require(:genre).permit(
      :name,
      :description
    )
  end
end
```

`genre_params` returns an instance of ActionController::Parameters, so if I want to add a sig to the method that says that, `@genre.update(genre_params)` would have a type error. I use this quite a lot in my Rails app, so I know it works.