### PR TITLE
Run tests for each gem + version in isolation

### DIFF
--- a/.ci/run.rb
+++ b/.ci/run.rb
@@ -1,13 +1,28 @@
 #!/usr/bin/env ruby
 
-# Exclude files if necessary here.
+# Exclude gems if necessary here.
 exclude = []
-
-file_paths = Dir.glob("**/*.rb{i,}").select{|p| !exclude.include?(p)}.map{|p| "\"#{p}\""}.join(' ')
 
 srb_cmd = 'tc'
 
 srb_flags = '--error-black-list 5002'
 
-# `exec` is used so the status code surfaces to CI
-exec("srb #{srb_cmd} #{srb_flags} #{file_paths}")
+gems = Dir.glob("lib/*").reject { |p| exclude.include?(p) }
+
+results =
+  gems.flat_map do |dir|
+    versions = Dir.glob(dir + '/*').map { |f| File.basename(f) }
+
+    # For each gem version, run the test and RBI files for that version and
+    # for the "all" directory.
+    versions.map do |version|
+      puts "testing #{File.basename(dir)} #{version}"
+      dirs = ["#{dir}/#{version}"]
+      dirs << "#{dir}/all" if versions.include?('all')
+      dirs = dirs.uniq.map { |d| "\"#{d}\"" }.join(' ')
+      system("srb #{srb_cmd} #{srb_flags} #{dirs}")
+    end
+  end
+
+# If any gem typecheck commands fail the entire CI run will fail.
+exit results.compact.all?

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To add `.rbi` files for a particular gem:
 1. Add a subdirectory to `lib` with the same name as the gem.
 2. Add a subdirectory to the gem subdirectory with a name matching the version you are adding signatures to. (See [Version Constraints](#version-constraints) below for a more thorough explanation)
 3. Create the `json-schema.rbi` file in the version directory you've chosen.
-4. Optional, but encouraged: Add a test file in `lib/gem_name/test/gem_name_test.rb`. See the [Testing section](#testing) for details.
+4. Optional, but encouraged: Add a test file in `lib/gem_name/version/gem_name_test.rb`. See the [Testing section](#testing) for details.
 
 ### Version Constraints
 
@@ -62,9 +62,9 @@ You can make sure your `.rbi` passes typechecking by installing the latest versi
 
 ### Tests
 
-There's basic support in sorbet-typed for testing of type signatures. Right now, you can only have valid usage of your methods in tests. This can be used to ensure the type signatures aren't causing typecheck failures on valid code. The test file for a gem should be placed at `lib/gem_name/test/gem_name_test.rb`.
+There's basic support in sorbet-typed for testing of type signatures. Right now, you can only have valid usage of your methods in tests. This can be used to ensure the type signatures aren't causing typecheck failures on valid code. The test file for a gem should be placed at `lib/gem_name/version/gem_name_test.rb`.
 
-For example, if you wanted to test the signatures for the `validates` method in the Rails gem `activemodel`, you could create a file at `lib/activemodel/test/activemodel_test.rb` like this:
+For example, if you wanted to test the signatures for the `validates` method in all versions of the Rails gem `activemodel`, you could create a file at `lib/activemodel/all/activemodel_test.rb` like this:
 
 ```ruby
 # typed: true
@@ -77,7 +77,7 @@ module ActiveModelTest
 end
 ```
 
-This tests a few of the parameters available on the `validates` method based on existing code from the ActiveModel documentation or active codebases using the gem.
+This tests a few of the parameters available on the `validates` method based on existing code from the ActiveModel documentation or active codebases using the gem. If you wanted to restrict your test to a type signature for a specific version of the gem, for example `activerecord ~> 5.2.0`, you would add your tests to that directory (`lib/activerecord/~>5.2.0/activerecord_test.rb` insead of the `all` one.
 
 The tests can be run locally by installing Sorbet with `gem install sorbet` and then running `ruby .ci/run.rb`.
 

--- a/lib/actionpack/all/actionpack_test.rb
+++ b/lib/actionpack/all/actionpack_test.rb
@@ -37,16 +37,16 @@ module ActionPackRoutesTest
   resources :articles do
     resources :comments, shallow: true
   end
-  
+
   resources :articles, shallow: true do
     resources :comments
   end
-  
+
   resources :photos do
     member do
       get 'preview'
     end
-  
+
     collection do
       get 'search'
     end
@@ -62,11 +62,11 @@ module ActionPackRoutesTest
   put 'about' => 'static_pages#about'
 
   get 'profile', action: :show, controller: 'users'
-  
+
   get 'photos(/:id)', to: :display
   get 'photos/:id', to: 'photos#show', defaults: { format: 'jpg' }
   get 'exit', to: 'sessions#destroy', as: :logout
-  
+
   match 'photos', to: 'photos#show', via: [:get, :post]
   match 'photos', to: 'photos#show', via: :all
   match 'path', to: 'controller#action', via: :post

--- a/lib/activemodel/all/activemodel_test.rb
+++ b/lib/activemodel/all/activemodel_test.rb
@@ -17,7 +17,7 @@ module ActiveModelTest
 
   validates :name, :login, :email, presence: true
   validates :order, presence: true
-  
+
   validates :name, :login, :email, absence: true
 
   validates :email, uniqueness: true
@@ -37,7 +37,7 @@ module ActiveModelTest
   validates :age, numericality: true, on: :update
 
   validates :token, presence: true, uniqueness: true, strict: TokenGenerationException
-  
+
   validates :card_number, presence: true, if: :paid_with_card?
 
   # TODO: These are valid but currently fail typechecking.

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -8,7 +8,7 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
     create_table :products do |t|
       t.string :name
       t.text :description
- 
+
       t.timestamps
     end
 
@@ -46,7 +46,7 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
     remove_foreign_key :accounts, :branches
     remove_foreign_key :accounts, column: :owner_id
     remove_foreign_key :accounts, name: :special_fk_name
-    
+
     execute <<-SQL
       ALTER TABLE distributors
         DROP CONSTRAINT zipchk
@@ -61,14 +61,13 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
         t.timestamps
       end
     end
- 
+
     say "Created a table"
- 
+
     suppress_messages { add_index :products, :name }
     say "and an index!", true
- 
+
     say_with_time 'Waiting for a while' do
-      sleep 10
       250
     end
   end

--- a/lib/activesupport/all/activesupport_test.rb
+++ b/lib/activesupport/all/activesupport_test.rb
@@ -40,7 +40,7 @@ module ActiveSupportNumberHelperTest
   number_to_percentage('98a')
   number_to_percentage(100, format: '%n  %')
 
-  number_to_phone(5551234) 
+  number_to_phone(5551234)
   number_to_phone('5551234')
   number_to_phone(1235551234, area_code: true, extension: 555)
   number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: '.')


### PR DESCRIPTION
As the test harness is currently setup, if one version of a gem has a
signature that conflicts with another version of the same gem (or any
other gem), then the tests will never succeed because the two versions
will conflict with each other. This change resolves these issues by
running each gem and version combination (along with the respective
`all` directory for that gem) in isolation. A failure to type-check any
one gem + version combination will fail the test harness script.