### PR TITLE
ActionPack action callbacks and respond_to sigs

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -608,3 +608,17 @@ module AbstractController::Callbacks::ClassMethods
   end
   def skip_before_action(*names, except: nil, only: nil, if: nil, unless: nil); end
 end
+
+# https://api.rubyonrails.org/classes/ActionController/MimeResponds.html
+module ActionController::MimeResponds
+  sig do
+    params(
+      mimes: T.nilable(Symbol),
+      block: T.nilable(T.proc.params(arg0: ActionController::MimeResponds::Collector).void)
+    ).void
+  end
+  def respond_to(*mimes, &block); end
+end
+
+class ActionController::MimeResponds::Collector
+end

--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -461,3 +461,150 @@ module ActionDispatch::Routing::Mapper::Resources
   sig { returns(T::Boolean) }
   def shallow?; end
 end
+
+# https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html
+module AbstractController::Callbacks::ClassMethods
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def after_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  # append_after_action is an alias of after_action
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def append_after_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  # append_around_action is an alias of around_action
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def append_around_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  # append_before_action is an alias of before_action
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def append_before_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def around_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def before_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def prepend_after_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def prepend_around_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      block: T.nilable(T.proc.returns(T.untyped))
+    ).void
+  end
+  def prepend_before_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc))
+    ).void
+  end
+  def skip_after_action(*names, except: nil, only: nil, if: nil, unless: nil); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc))
+    ).void
+  end
+  def skip_around_action(*names, except: nil, only: nil, if: nil, unless: nil); end
+
+  sig do
+    params(
+      names: Symbol,
+      except: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      only: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc))
+    ).void
+  end
+  def skip_before_action(*names, except: nil, only: nil, if: nil, unless: nil); end
+end

--- a/lib/actionpack/test/actionpack_test.rb
+++ b/lib/actionpack/test/actionpack_test.rb
@@ -102,3 +102,88 @@ class ActionPackMetalTest < ActionController::Metal
     )
   end
 end
+
+module ActionPackCallbacksTest
+  extend AbstractController::Callbacks::ClassMethods
+
+  # Test without any options.
+  prepend_before_action :action_name
+  before_action :action_name
+  append_before_action :action_name
+  skip_before_action :action_name
+
+  prepend_around_action :action_name
+  around_action :action_name
+  append_around_action :action_name
+  skip_around_action :action_name
+
+  prepend_after_action :action_name
+  after_action :action_name
+  append_after_action :action_name
+  skip_after_action :action_name
+
+
+  # Test with multiple actions.
+  prepend_before_action :action_name, :action_name_2
+  before_action :action_name, :action_name_2
+  append_before_action :action_name, :action_name_2
+  skip_before_action :action_name, :action_name_2
+
+  prepend_around_action :action_name, :action_name_2
+  around_action :action_name, :action_name_2
+  append_around_action :action_name, :action_name_2
+  skip_around_action :action_name, :action_name_2
+
+  prepend_after_action :action_name, :action_name_2
+  after_action :action_name, :action_name_2
+  append_after_action :action_name, :action_name_2
+  skip_after_action :action_name, :action_name_2
+
+
+  # Test using a block. (skip_* methods don't accept a block)
+  prepend_before_action :action_name, only: :show { |controller| puts controller }
+  before_action :action_name, only: :show { |controller| puts controller }
+  append_before_action :action_name, only: :show { |controller| puts controller }
+
+  prepend_around_action :action_name, only: :show { |controller| puts controller }
+  around_action :action_name, only: :show { |controller| puts controller }
+  append_around_action :action_name, only: :show { |controller| puts controller }
+
+  prepend_after_action :action_name, only: :show { |controller| puts controller }
+  after_action :action_name, only: :show { |controller| puts controller }
+  append_after_action :action_name, only: :show { |controller| puts controller }
+
+
+  # Test proc for `if`, symbol for `only`, symbol array for `except`.
+  prepend_before_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  before_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  append_before_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  skip_before_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+
+  prepend_around_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  around_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  append_around_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  skip_around_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+
+  prepend_after_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  after_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  append_after_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+  skip_after_action :action_name, if: -> { true }, only: :show, except: [:edit, :delete]
+
+
+  # Test symbol for `if`, symbol array for `only`, symbol for `except`.
+  prepend_before_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  before_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  append_before_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  skip_before_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+
+  prepend_around_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  around_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  append_around_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  skip_around_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+
+  prepend_after_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  after_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  append_after_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+  skip_after_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
+end

--- a/lib/actionpack/test/actionpack_test.rb
+++ b/lib/actionpack/test/actionpack_test.rb
@@ -187,3 +187,16 @@ module ActionPackCallbacksTest
   append_after_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
   skip_after_action :action_name, if: :method_name?, only: [:show, :delete], except: :edit
 end
+
+module ActionPackMimeRespondsTest
+  extend ActionController::MimeResponds
+
+  respond_to :html, :js
+
+  # Don't call any methods on format because the class it returns has methods
+  # generated dynamically based on what mime types have been registered,
+  # and we can't type those statically.
+  respond_to do |format|
+    format
+  end
+end


### PR DESCRIPTION
This adds sigs and tests for [`respond_to`](https://api.rubyonrails.org/classes/ActionController/MimeResponds.html#method-i-respond_to) and [`before_action`, `after_action`, etc.](https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html).