### PR TITLE
Change activesupport safe_constantize to untyped

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -186,7 +186,7 @@ class String
   sig { params(patterns: T.untyped).returns(T.untyped) }
   def remove(*patterns); end
 
-  sig { returns(T.nilable(String)) }
+  sig { returns(T.untyped) }
   def safe_constantize; end
 
   sig { params(locale: Symbol).returns(T.nilable(String)) }


### PR DESCRIPTION
`safe_constantize` returns either the value of the constant whose name is the same as the string it's called on or `nil` if that constant isn't defined. Since a constant can potentially have any value, `safe_constantize` should be untyped.