### PR TITLE
Remove unnecessary extra Regex assignment

### DIFF
--- a/lib/ruby/all/resolv.rbi
+++ b/lib/ruby/all/resolv.rbi
@@ -516,7 +516,7 @@ class Resolv
     end
 
     class Alt
-      Regex = Regex = T.let(T.unsafe(nil), Regexp)
+      Regex = T.let(T.unsafe(nil), Regexp)
 
       sig { params(arg: T.any(String, Resolv::LOC::Alt)).returns(Resolv::LOC::Alt) }
       def self.create(arg); end


### PR DESCRIPTION
Replace `Regex = Regex = blah` with `Regex = blah`, especially now that the former would require a `T.let` in `strict`.