### PR TITLE
ActiveRecord Table, TableDefinition, ColumnMethods sigs

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1177,3 +1177,129 @@ module ActiveRecord::ConnectionAdapters::ColumnMethods
   end
   def virtual(*names, index: nil, default: nil, **options); end
 end
+
+class ActiveRecord::ConnectionAdapters::Table
+  # Checks to see if a column exists.
+  #
+  # ```ruby
+  # t.string(:name) unless t.column_exists?(:name, :string)
+  # ```
+  sig { params(column_name: T.any(String, Symbol), type: Symbol, options: T.untyped).returns(T::Boolean) }
+  def column_exists?(column_name, type = nil, options = {}); end
+
+  # Checks to see if an index exists.
+  #
+  # ```ruby
+  # unless t.index_exists?(:branch_id)
+  #   t.index(:branch_id)
+  # end
+  # ```
+  sig { params(column_name: T.any(String, Symbol), options: T.untyped).returns(T::Boolean) }
+  def index_exists?(column_name, options = {}); end
+
+  # Renames the given index on the table.
+  #
+  # ```ruby
+  # t.rename_index(:user_id, :account_id)
+  # ```
+  sig { params(index_name: T.any(String, Symbol), new_index_name: T.any(String, Symbol)).void }
+  def rename_index(index_name, new_index_name); end
+
+  # Changes the column's definition according to the new options.
+  #
+  # ```ruby
+  # t.change(:name, :string, limit: 80)
+  # t.change(:description, :text)
+  # ```
+  sig { params(column_name: T.any(String, Symbol), type: Symbol, options: T.untyped).void }
+  def change(column_name, type, options = {}); end
+
+  # Sets a new default value for a column.
+  #
+  # ```ruby
+  # t.change_default(:qualification, 'new')
+  # t.change_default(:authorized, 1)
+  # t.change_default(:status, from: nil, to: "draft")
+  # ```
+  sig { params(column_name: T.any(String, Symbol), default_or_changes: T.untyped).void }
+  def change_default(column_name, default_or_changes); end
+
+  # Removes the column(s) from the table definition.
+  #
+  # ```ruby
+  # t.remove(:qualification)
+  # t.remove(:qualification, :experience)
+  # ```
+  sig { params(column_names: T.any(String, Symbol)).void }
+  def remove(*column_names); end
+
+  # Removes the given index from the table.
+  #
+  # ```ruby
+  # t.remove_index(:branch_id)
+  # t.remove_index(column: [:branch_id, :party_id])
+  # t.remove_index(name: :by_branch_party)
+  # ```
+  sig { params(options: T.untyped).void }
+  def remove_index(options = {}); end
+
+  # Removes the timestamp columns (`created_at` and `updated_at`) from the table.
+  #
+  # ```ruby
+  # t.remove_timestamps
+  # ```
+  sig { params(options: T.untyped).void }
+  def remove_timestamps(options = {}); end
+
+  # Renames a column.
+  #
+  # ```ruby
+  # t.rename(:description, :name)
+  # ```
+  sig { params(column_name: T.any(String, Symbol), new_column_name: T.any(String, Symbol)).void }
+  def rename(column_name, new_column_name); end
+
+  # Removes a reference. Optionally removes a `type` column.
+  #
+  # ```ruby
+  # t.remove_references(:user)
+  # t.remove_belongs_to(:supplier, polymorphic: true)
+  # ```
+  sig { params(args: T.untyped, options: T.untyped).void }
+  def remove_references(*args, **options); end
+
+  # Removes a reference. Optionally removes a `type` column.
+  #
+  # ```ruby
+  # t.remove_references(:user)
+  # t.remove_belongs_to(:supplier, polymorphic: true)
+  # ```
+  sig { params(args: T.untyped, options: T.untyped).void }
+  def remove_belongs_to(*args, **options); end
+
+  # Adds a foreign key to the table using a supplied table name.
+  #
+  # ```ruby
+  # t.foreign_key(:authors)
+  # t.foreign_key(:authors, column: :author_id, primary_key: "id")
+  # ```
+  sig { params(args: T.untyped).void }
+  def foreign_key(*args); end
+
+  # Removes the given foreign key from the table.
+  #
+  # ```ruby
+  # t.remove_foreign_key(:authors)
+  # t.remove_foreign_key(column: :author_id)
+  # ```
+  sig { params(args: T.untyped).void }
+  def remove_foreign_key(*args); end
+
+  # Checks to see if a foreign key exists.
+  #
+  # ```ruby
+  # t.foreign_key(:authors) unless t.foreign_key_exists?(:authors)
+  # ```
+  sig { params(args: T.untyped).returns(T::Boolean) }
+  def foreign_key_exists?(*args); end
+end

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -918,7 +918,7 @@ end
 # Represents the schema of an SQL table in an abstract way. This class
 # provides methods for manipulating the schema representation.
 #
-# Inside migration files, the +t+ object in {create_table}[rdoc-ref:SchemaStatements#create_table]
+# Inside migration files, the `t` object in `create_table`
 # is actually of this type:
 #
 # ```ruby
@@ -930,7 +930,7 @@ end
 #   end
 #
 #   def down
-#     ...
+#     # ...
 #   end
 # end
 # ```
@@ -941,7 +941,7 @@ class ActiveRecord::ConnectionAdapters::TableDefinition
   sig { returns(T::Array[ActiveRecord::ConnectionAdapters::ColumnDefinition]) }
   def columns; end
 
-  # Returns a ColumnDefinition for the column with name +name+.
+  # Returns a ColumnDefinition for the column with name `name`.
   sig { params(name: T.any(String, Symbol)).returns(ActiveRecord::ConnectionAdapters::ColumnDefinition) }
   def [](name); end
 
@@ -1241,7 +1241,7 @@ class ActiveRecord::ConnectionAdapters::Table
   sig { params(column_name: T.any(String, Symbol), type: Symbol, options: T.untyped).returns(T::Boolean) }
   def column_exists?(column_name, type = nil, options = {}); end
 
-  # Adds a new index to the table. +column_name+ can be a single Symbol, or
+  # Adds a new index to the table. `column_name` can be a single Symbol, or
   # an Array of Symbols.
   #
   # ```ruby
@@ -1275,7 +1275,7 @@ class ActiveRecord::ConnectionAdapters::Table
   sig { params(index_name: T.any(String, Symbol), new_index_name: T.any(String, Symbol)).void }
   def rename_index(index_name, new_index_name); end
 
-  # Adds timestamps (+created_at+ and +updated_at+) columns to the table.
+  # Adds timestamps (`created_at` and `updated_at`) columns to the table.
   #
   # ```ruby
   # t.timestamps(null: false)

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -915,7 +915,6 @@ module ActiveRecord::Validations
   mixes_in_class_methods(ActiveModel::Validations::ClassMethods)
 end
 
-
 # Represents the schema of an SQL table in an abstract way. This class
 # provides methods for manipulating the schema representation.
 #
@@ -1245,7 +1244,12 @@ class ActiveRecord::ConnectionAdapters::Table
   # t.index([:branch_id, :party_id], unique: true)
   # t.index([:branch_id, :party_id], unique: true, name: 'by_branch_party')
   # ```
-  sig { params(column_name: T.any(String, Symbol), options: T.untyped).void }
+  sig do
+    params(
+      column_name: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
+      options: T.untyped
+    ).void
+  end
   def index(column_name, options = {}); end
 
   # Checks to see if an index exists.

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -914,3 +914,266 @@ module ActiveRecord::Validations
 
   mixes_in_class_methods(ActiveModel::Validations::ClassMethods)
 end
+
+
+# Represents the schema of an SQL table in an abstract way. This class
+# provides methods for manipulating the schema representation.
+#
+# Inside migration files, the +t+ object in {create_table}[rdoc-ref:SchemaStatements#create_table]
+# is actually of this type:
+#
+# ```ruby
+# class SomeMigration < ActiveRecord::Migration[5.0]
+#   def up
+#     create_table :foo do |t|
+#       puts t.class  # => "ActiveRecord::ConnectionAdapters::TableDefinition"
+#     end
+#   end
+#
+#   def down
+#     ...
+#   end
+# end
+# ```
+class ActiveRecord::ConnectionAdapters::TableDefinition
+  include ActiveRecord::ConnectionAdapters::ColumnMethods
+
+  # Returns an array of ColumnDefinition objects for the columns of the table.
+  sig { returns(T::Array[ActiveRecord::ConnectionAdapters::ColumnDefinition]) }
+  def columns; end
+
+  # Returns a ColumnDefinition for the column with name +name+.
+  sig { params(name: T.any(String, Symbol)).returns(ActiveRecord::ConnectionAdapters::ColumnDefinition) }
+  def [](name); end
+
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      type: T.untyped,
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).returns(T.self_type)
+  end
+  def column(
+    name,
+    type,
+    index: nil,
+    default: nil,
+    **options
+  ); end
+
+  # Remove the column `name` from the table.
+  #
+  # ```ruby
+  # remove_column(:account_id)
+  # ```
+  sig { params(name: T.any(String, Symbol)).void }
+  def remove_column(name); end
+
+  # Adds index options to the indexes hash, keyed by column name
+  # This is primarily used to track indexes that need to be created after the table
+  #
+  # ```ruby
+  # index(:account_id, name: 'index_projects_on_account_id')
+  # ```
+  sig { params(column_name: T.any(String, Symbol), options: T.untyped).void }
+  def index(column_name, options = {}); end
+
+  # Appends `:datetime` columns `:created_at` and
+  # `:updated_at` to the table.
+  #
+  # ```ruby
+  # t.timestamps null: false
+  # ```
+  sig { params(options: T.untyped).void }
+  def timestamps(**options); end
+
+  # Adds a reference.
+  #
+  # ```ruby
+  # t.references(:user)
+  # t.belongs_to(:supplier, foreign_key: true)
+  # t.belongs_to(:supplier, foreign_key: true, type: :integer)
+  # ```
+  sig { params(args: T.untyped, options: T.untyped).void }
+  def references(*args, **options); end
+
+  # Adds a reference.
+  #
+  # ```ruby
+  # t.references(:user)
+  # t.belongs_to(:supplier, foreign_key: true)
+  # t.belongs_to(:supplier, foreign_key: true, type: :integer)
+  # ```
+  sig { params(args: T.untyped, options: T.untyped).void }
+  def belongs_to(*args, **options); end
+end
+
+module ActiveRecord::ConnectionAdapters::ColumnMethods
+  # Appends a primary key definition to the table definition.
+  # Can be called multiple times, but this is probably not a good idea.
+  sig do
+    params(
+      name: T.any(String, Symbol),
+      type: T.any(String, Symbol),
+      options: T.untyped
+    ).void
+  end
+  def primary_key(name, type = :primary_key, **options); end
+
+  ########
+  # NOTE: The following methods are all generated dynamically and have the same parameters.
+  # See https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L217
+  ########
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def bigint(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def binary(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def boolean(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def date(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def datetime(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def decimal(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def numeric(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def float(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def integer(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def json(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def string(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def text(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def time(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def timestamp(*names, index: nil, default: nil, **options); end
+
+  sig do
+    params(
+      names: T.any(String, Symbol),
+      index: T.any(T::Hash[T.untyped, T.untyped], T::Boolean),
+      default: T.untyped,
+      options: T.untyped
+    ).void
+  end
+  def virtual(*names, index: nil, default: nil, **options); end
+end

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1178,7 +1178,57 @@ module ActiveRecord::ConnectionAdapters::ColumnMethods
   def virtual(*names, index: nil, default: nil, **options); end
 end
 
+# Represents an SQL table in an abstract way for updating a table.
+#
+# Available transformations are:
+#
+# ```ruby
+# change_table :table do |t|
+#   t.primary_key
+#   t.column
+#   t.index
+#   t.rename_index
+#   t.timestamps
+#   t.change
+#   t.change_default
+#   t.rename
+#   t.references
+#   t.belongs_to
+#   t.string
+#   t.text
+#   t.integer
+#   t.bigint
+#   t.float
+#   t.decimal
+#   t.numeric
+#   t.datetime
+#   t.timestamp
+#   t.time
+#   t.date
+#   t.binary
+#   t.boolean
+#   t.foreign_key
+#   t.json
+#   t.virtual
+#   t.remove
+#   t.remove_foreign_key
+#   t.remove_references
+#   t.remove_belongs_to
+#   t.remove_index
+#   t.remove_timestamps
+# end
+# ```
 class ActiveRecord::ConnectionAdapters::Table
+  include ActiveRecord::ConnectionAdapters::ColumnMethods
+
+  # Adds a new column to the named table.
+  #
+  # ```ruby
+  # t.column(:name, :string)
+  # ```
+  sig { params(column_name: T.any(String, Symbol), type: Symbol, options: T.untyped).void }
+  def column(column_name, type, **options); end
+
   # Checks to see if a column exists.
   #
   # ```ruby
@@ -1186,6 +1236,17 @@ class ActiveRecord::ConnectionAdapters::Table
   # ```
   sig { params(column_name: T.any(String, Symbol), type: Symbol, options: T.untyped).returns(T::Boolean) }
   def column_exists?(column_name, type = nil, options = {}); end
+
+  # Adds a new index to the table. +column_name+ can be a single Symbol, or
+  # an Array of Symbols.
+  #
+  # ```ruby
+  # t.index(:name)
+  # t.index([:branch_id, :party_id], unique: true)
+  # t.index([:branch_id, :party_id], unique: true, name: 'by_branch_party')
+  # ```
+  sig { params(column_name: T.any(String, Symbol), options: T.untyped).void }
+  def index(column_name, options = {}); end
 
   # Checks to see if an index exists.
   #
@@ -1204,6 +1265,13 @@ class ActiveRecord::ConnectionAdapters::Table
   # ```
   sig { params(index_name: T.any(String, Symbol), new_index_name: T.any(String, Symbol)).void }
   def rename_index(index_name, new_index_name); end
+
+  # Adds timestamps (+created_at+ and +updated_at+) columns to the table.
+  #
+  # ```ruby
+  # t.timestamps(null: false)
+  # ```
+  def timestamps(options = {}); end
 
   # Changes the column's definition according to the new options.
   #
@@ -1258,6 +1326,24 @@ class ActiveRecord::ConnectionAdapters::Table
   # ```
   sig { params(column_name: T.any(String, Symbol), new_column_name: T.any(String, Symbol)).void }
   def rename(column_name, new_column_name); end
+
+  # Adds a reference.
+  #
+  # ```ruby
+  # t.references(:user)
+  # t.belongs_to(:supplier, foreign_key: true)
+  # ```
+  sig { params(args: T.untyped, options: T.untyped).void }
+  def references(*args, **options); end
+
+  # Adds a reference.
+  #
+  # ```ruby
+  # t.references(:user)
+  # t.belongs_to(:supplier, foreign_key: true)
+  # ```
+  sig { params(args: T.untyped, options: T.untyped).void }
+  def belongs_to(*args, **options); end
 
   # Removes a reference. Optionally removes a `type` column.
   #

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -976,7 +976,12 @@ class ActiveRecord::ConnectionAdapters::TableDefinition
   # ```ruby
   # index(:account_id, name: 'index_projects_on_account_id')
   # ```
-  sig { params(column_name: T.any(String, Symbol), options: T.untyped).void }
+  sig do
+    params(
+      column_name: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
+      options: T.untyped
+    ).void
+  end
   def index(column_name, options = {}); end
 
   # Appends `:datetime` columns `:created_at` and

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -68,7 +68,7 @@ class ActiveRecordCallbacksTest < ApplicationRecord
 end
 
 class ActiveRecordMigrationsTest
-  def test
+  def test_table
     # Hack around the fact that change_table isn't included in the all/activerecord.rbi.
     # Normally this'd be more like `change_table :foo do |t|`.
     t = ActiveRecord::ConnectionAdapters::Table.new
@@ -120,5 +120,29 @@ class ActiveRecordMigrationsTest
     t.remove_foreign_key(column: :author_id)
 
     t.foreign_key(:authors) unless t.foreign_key_exists?(:authors)
+  end
+
+  def test_table_definitions
+    # Hack around the fact that create_table isn't included in the all/activerecord.rbi.
+    # Normally this'd be more like `create_table :foo do |t|`.
+    t = ActiveRecord::ConnectionAdapters::TableDefinition.new
+
+    t.string :foo
+    t.text :foo
+    t.integer :foo
+    t.bigint :foo
+    t.float :foo
+    t.decimal :foo
+    t.numeric :foo
+    t.datetime :foo
+    t.timestamp :foo
+    t.time :foo
+    t.date :foo
+    t.binary :foo
+    t.boolean :foo
+    t.json :foo
+    t.virtual :foo
+
+    t.index [:foo, :bar], name: "index_foo_bar", unique: true
   end
 end

--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -39,7 +39,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     params(
       table_name: T.any(String, Symbol),
       bulk: T::Boolean,
-      blk: T.nilable(T.proc.params(t: ActiveRecord::ConnectionAdapters::TableDefinition).void)
+      blk: T.nilable(T.proc.params(t: ActiveRecord::ConnectionAdapters::Table).void)
     ).void
   end
   def change_table(

--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -332,7 +332,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
   sig do
     params(
       table_name: T.any(String, Symbol),
-      index_name: T.any(String, Symbol),
+      column_name: T.any(String, Symbol),
       options: T.untyped
     ).returns(T::Boolean)
   end

--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -39,7 +39,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     params(
       table_name: T.any(String, Symbol),
       bulk: T::Boolean,
-      blk: T.nilable(T.proc.params(t: ActiveRecord::ConnectionAdapters::Table).void)
+      blk: T.proc.params(t: ActiveRecord::ConnectionAdapters::Table).void
     ).void
   end
   def change_table(

--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -329,6 +329,21 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     new_name
   ); end
 
+  sig do
+    params(
+      table_name: T.any(String, Symbol),
+      index_name: T.any(String, Symbol),
+      options: T.untyped
+    ).returns(T::Boolean)
+  end
+  def index_exists?(table_name, column_name, options = {}); end
+
+  sig { params(table_name: T.any(String, Symbol), index_name: T.any(String, Symbol)).returns(T::Boolean) }
+  def index_name_exists?(table_name, index_name); end
+
+  sig { params(table_name: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+  def indexes(table_name); end
+
   # References
 
   sig do

--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -238,6 +238,20 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     validate: true
   ); end
 
+  sig do
+    params(
+      from_table: T.any(String, Symbol),
+      to_table: T.any(String, Symbol),
+      name: T.any(String, Symbol),
+      column: T.any(String, Symbol),
+      options: T.untyped
+    ).returns(T::Boolean)
+  end
+  def foreign_key_exists?(from_table, to_table = nil, name: nil, column: nil, **options); end
+
+  sig { params(table_name: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+  def foreign_keys(table_name); end
+
   # Indices
 
   sig do

--- a/lib/activerecord/~>5.2.0/activerecord_test.rb
+++ b/lib/activerecord/~>5.2.0/activerecord_test.rb
@@ -76,6 +76,9 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
     remove_foreign_key :accounts, :branches
     remove_foreign_key :accounts, column: :owner_id
     remove_foreign_key :accounts, :branches, name: :special_fk_name
+    foreign_key_exists?(:accounts, :branches)
+    foreign_key_exists?(:accounts, column: :owner_id)
+    foreign_key_exists?(:accounts, name: "special_fk_name")
 
     execute <<-SQL
       ALTER TABLE distributors

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -71,7 +71,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     params(
       table_name: T.any(String, Symbol),
       bulk: T::Boolean,
-      blk: T.nilable(T.proc.params(t: ActiveRecord::ConnectionAdapters::Table).void)
+      blk: T.proc.params(t: ActiveRecord::ConnectionAdapters::Table).void
     ).void
   end
   def change_table(

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -364,7 +364,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
   sig do
     params(
       table_name: T.any(String, Symbol),
-      index_name: T.any(String, Symbol),
+      column_name: T.any(String, Symbol),
       options: T.untyped
     ).returns(T::Boolean)
   end

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -71,7 +71,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     params(
       table_name: T.any(String, Symbol),
       bulk: T::Boolean,
-      blk: T.nilable(T.proc.params(t: ActiveRecord::ConnectionAdapters::TableDefinition).void)
+      blk: T.nilable(T.proc.params(t: ActiveRecord::ConnectionAdapters::Table).void)
     ).void
   end
   def change_table(

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -361,6 +361,21 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     new_name
   ); end
 
+  sig do
+    params(
+      table_name: T.any(String, Symbol),
+      index_name: T.any(String, Symbol),
+      options: T.untyped
+    ).returns(T::Boolean)
+  end
+  def index_exists?(table_name, column_name, options = {}); end
+
+  sig { params(table_name: T.any(String, Symbol), index_name: T.any(String, Symbol)).returns(T::Boolean) }
+  def index_name_exists?(table_name, index_name); end
+
+  sig { params(table_name: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+  def indexes(table_name); end
+
   # References
 
   sig do

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -270,6 +270,20 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     validate: true
   ); end
 
+  sig do
+    params(
+      from_table: T.any(String, Symbol),
+      to_table: T.any(String, Symbol),
+      name: T.any(String, Symbol),
+      column: T.any(String, Symbol),
+      options: T.untyped
+    ).returns(T::Boolean)
+  end
+  def foreign_key_exists?(from_table, to_table = nil, name: nil, column: nil, **options); end
+
+  sig { params(table_name: T.any(String, Symbol)).returns(T::Array[T.untyped]) }
+  def foreign_keys(table_name); end
+
   # Indices
 
   sig do

--- a/lib/activerecord/~>6.0.0/activerecord_test.rb
+++ b/lib/activerecord/~>6.0.0/activerecord_test.rb
@@ -80,6 +80,9 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
     remove_foreign_key :accounts, :branches
     remove_foreign_key :accounts, column: :owner_id
     remove_foreign_key :accounts, :branches, name: :special_fk_name
+    foreign_key_exists?(:accounts, :branches)
+    foreign_key_exists?(:accounts, column: :owner_id)
+    foreign_key_exists?(:accounts, name: "special_fk_name")
 
     execute <<-SQL
       ALTER TABLE distributors


### PR DESCRIPTION
Add methods, signatures, and docs for [`ActiveRecord::ConnectionAdapters::Table`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html), [`ActiveRecord::ConnectionAdapters::TableDefinition`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html), and [`ActiveRecord::ConnectionAdapters::ColumnMethods`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ColumnMethods.html).

Also fix the `change_table` method to return `ActiveRecord::ConnectionAdapters::Table` in the block instead of `ActiveRecord::ConnectionAdapters::TableDefinition`.