### PR TITLE
Add some response formats to the mime collector

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -834,4 +834,15 @@ module ActionController::MimeResponds
 end
 
 class ActionController::MimeResponds::Collector
+  sig { params(block: T.nilable(T.proc.void)).void }
+  def html(&block); end
+
+  sig { params(block: T.nilable(T.proc.void)).void }
+  def js(&block); end
+
+  sig { params(block: T.nilable(T.proc.void)).void }
+  def json(&block); end
+
+  sig { params(block: T.nilable(T.proc.void)).void }
+  def xml(&block); end
 end

--- a/lib/actionpack/all/actionpack_test.rb
+++ b/lib/actionpack/all/actionpack_test.rb
@@ -201,6 +201,13 @@ module ActionPackMimeRespondsTest
   # generated dynamically based on what mime types have been registered,
   # and we can't type those statically.
   respond_to do |format|
-    format
+    format.html
+    format.html { 1 }
+    format.js
+    format.js { 1 }
+    format.json
+    format.json { 1 }
+    format.xml
+    format.xml { 1 }
   end
 end


### PR DESCRIPTION
There are a lot of documented ways the mime collector can be used. This
change provides signatures for one of the most common (by providing an
optional block). I have chosen to include four basic mime types to begin
with.