### PR TITLE
Add some class methods that are mixed into ActionView.

### DIFF
--- a/lib/actionview/all/actionview.rbi
+++ b/lib/actionview/all/actionview.rbi
@@ -266,3 +266,15 @@ module ActionView::Helpers::UrlHelper
   sig { params(options: T.untyped, check_parameters: T::Boolean).returns(T::Boolean) }
   def current_page?(options, check_parameters: false); end
 end
+
+module ActionView::Layouts
+  mixes_in_class_methods(ActionView::Layouts::ClassMethods)
+end
+
+module ActionView::Rendering
+  mixes_in_class_methods(ActionView::Rendering::ClassMethods)
+end
+
+module ActionView::ViewPaths
+  mixes_in_class_methods(ActionView::ViewPaths::ClassMethods)
+end


### PR DESCRIPTION
In controllers, you can set the HTML ERB layout that will be used for the pages within that controller, but Sorbet doesn't know the `layout` method exists until you tell it to mix the class methods in.

https://api.rubyonrails.org/classes/ActionView/Layouts.html

https://api.rubyonrails.org/classes/ActionView/Layouts/ClassMethods.html

I've also done this for `ActionView::Rendering` and `ActionView::ViewPaths`