### PR TITLE
Fixed error 5002: Unable to resolve constant "ClassMethods"

### DIFF
--- a/lib/actionview/all/actionview.rbi
+++ b/lib/actionview/all/actionview.rbi
@@ -268,6 +268,8 @@ module ActionView::Helpers::UrlHelper
 end
 
 module ActionView::Layouts
+  extend T::Helpers  
+
   module ClassMethods ; end
   
   mixes_in_class_methods(ActionView::Layouts::ClassMethods)

--- a/lib/actionview/all/actionview.rbi
+++ b/lib/actionview/all/actionview.rbi
@@ -268,6 +268,8 @@ module ActionView::Helpers::UrlHelper
 end
 
 module ActionView::Layouts
+  module ClassMethods ; end
+  
   mixes_in_class_methods(ActionView::Layouts::ClassMethods)
 end
 


### PR DESCRIPTION
(Two new line added)

Fixed this error message so "typed:" can be "false".
```
sorbet/rbi/sorbet-typed/lib/actionview/all/actionview.rbi:278: 
Unable to resolve constant `ClassMethods` https://srb.help/5002
     278 |  mixes_in_class_methods(ActionView::Layouts::ClassMethods)
```
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^