### PR TITLE
Fix duplicate class inheritance.

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -866,7 +866,6 @@ module ActiveRecord
   class PreparedStatementCacheExpired < StatementInvalid; end
   class PreparedStatementInvalid < ActiveRecordError; end
   class ProtectedEnvironmentError < ActiveRecordError; end
-  class QueryCanceled < StatementInvalid; end
   class RangeError < StatementInvalid; end
   class ReadOnlyRecord < ActiveRecordError; end
   class RecordInvalid < ActiveRecordError; end
@@ -879,7 +878,6 @@ module ActiveRecord
   class SerializationTypeMismatch < ActiveRecordError; end
   class StaleObjectError < ActiveRecordError; end
   class StatementInvalid < ActiveRecordError; end
-  class StatementTimeout < StatementInvalid; end
   class SubclassNotFound < ActiveRecordError; end
   class ThroughCantAssociateThroughHasOneOrManyReflection < ActiveRecordError; end
   class ThroughNestedAssociationsAreReadonly < ActiveRecordError; end


### PR DESCRIPTION
When I run 'srb tc' after changing "typed:" from ignore to false, I get these two errors (5012):
```
sorbet/rbi/sorbet-typed/lib/activerecord/all/activerecord.rbi:876:
Parent of class ActiveRecord::QueryCanceled redefined from
ActiveRecord::QueryAborted to ActiveRecord::StatementInvalid https://srb.help/5012
     876 |  class QueryCanceled < StatementInvalid; end
                                  ^^^^^^^^^^^^^^^^

sorbet/rbi/sorbet-typed/lib/activerecord/all/activerecord.rbi:889:
Parent of class ActiveRecord::StatementTimeout redefined from
ActiveRecord::QueryAborted to ActiveRecord::StatementInvalid https://srb.help/5012
     889 |  class StatementTimeout < StatementInvalid; end
                                     ^^^^^^^^^^^^^^^^
Errors: 2
```

I checked the 'rails' repo and found this:
```
activerecord/lib/active_record/errors.rb:369:  class StatementTimeout < QueryAborted
activerecord/lib/active_record/errors.rb:373:  class QueryCanceled < QueryAborted
```

So I am going to remove the duplicates (2 lines) in this file: 
```
sorbet/rbi/sorbet-typed/lib/activerecord/all/activerecord.rbi
```