### PR TITLE
Add more Stripe API objects

### DIFF
--- a/lib/stripe/all/stripe.rbi
+++ b/lib/stripe/all/stripe.rbi
@@ -2,6 +2,9 @@
 
 class Stripe::Card
   sig { returns(String) }
+  def id; end
+
+  sig { returns(String) }
   def brand; end
 
   sig { params(other: String).returns(String) }
@@ -24,4 +27,83 @@ class Stripe::Card
 
   sig { params(other: String).returns(String) }
   def last4=(other); end
+
+  sig { params(id: String, opts: T.nilable(T::Hash)).returns(Stripe::Card) }
+  def self.retrieve(id, opts={}); end
+end
+
+class Stripe::Customer
+  sig { returns(String) }
+  def id; end
+
+  sig { params(id: String, opts: T.nilable(T::Hash)).returns(Stripe::Customer) }
+  def self.retrieve(id, opts={}); end
+
+  sig { returns(String) }
+  def name; end
+end
+
+class Stripe::Refund
+  sig { returns(String) }
+  def id; end
+
+  sig { params(id: String, opts: T.nilable(T::Hash)).returns(Stripe::Refund) }
+  def self.retrieve(id, opts={}); end
+
+  sig { returns(String) }
+  def charge; end
+end
+
+class Stripe::Charge
+  sig { returns(String) }
+  def id; end
+
+  sig { params(id: String, opts: T.nilable(T::Hash)).returns(Stripe::Charge) }
+  def self.retrieve(id, opts={}); end
+
+  sig { returns(String) }
+  def customer; end
+end
+
+class Stripe::Payout
+  sig { returns(String) }
+  def id; end
+
+  sig { returns(Integer) }
+  def created; end
+
+  sig { returns(Integer) }
+  def arrival_date; end
+
+  sig { returns(Integer) }
+  def amount; end
+
+  sig { params(id: String, opts: T.nilable(T::Hash)).returns(Stripe::Payout) }
+  def self.retrieve(id, opts={}); end
+end
+
+class Stripe::BalanceTransaction
+  sig { returns(String) }
+  def id; end
+
+  sig { returns(String) }
+  def type; end
+
+  sig { returns(String) }
+  def source; end
+
+  sig { returns(Integer) }
+  def amount; end
+
+  sig { returns(Integer) }
+  def fee; end
+
+  sig { returns(Integer) }
+  def net; end
+
+  sig { returns(Integer) }
+  def created; end
+
+  sig { params(id: String, opts: T.nilable(T::Hash)).returns(Stripe::BalanceTransaction) }
+  def self.retrieve(id, opts={}); end
 end


### PR DESCRIPTION
Our team uses Stripe API and Sorbet and we realized that Sorbet types for this gem are incomplete. 

We decided to contribute a bit with all those methods we use. Those Stripe objects have more methods, but we only can guarantee the ones we use.

As you can read [in this thread](https://github.com/stripe/stripe-ruby/issues/854) Stripe has the plan to add types for their gem in the future but meanwhile, these types can help someone.

