### PR TITLE
Add interface for Rails view contexts

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -1,6 +1,7 @@
 # typed: strong
 
 class ActionController::Base < ActionController::Metal
+  include ActionView::Layouts
 end
 
 class AbstractController::Base < Object

--- a/lib/actionview/all/actionview.rbi
+++ b/lib/actionview/all/actionview.rbi
@@ -286,6 +286,7 @@ module ActionView::Helpers::UrlHelper
 end
 
 module ActionView::Layouts
+  include ActionView::Rendering
   extend T::Helpers  
 
   module ClassMethods ; end
@@ -293,8 +294,26 @@ module ActionView::Layouts
   mixes_in_class_methods(ActionView::Layouts::ClassMethods)
 end
 
+module ActionView::ViewContext
+  extend T::Helpers
+  interface!
+
+  sig { abstract.params(lookup_context: T.untyped, assigns: T.untyped, controller: T.untyped).void }
+  def initialize(lookup_context, assigns, controller); end
+
+  sig { abstract.params(option: T.untyped).returns(String) }
+  def render(option); end
+end
+
+class ActionView::Base
+  include ActionView::ViewContext
+end
+
 module ActionView::Rendering
   mixes_in_class_methods(ActionView::Rendering::ClassMethods)
+
+  sig { returns(ActionView::ViewContext) }
+  def view_context; end
 end
 
 module ActionView::ViewPaths

--- a/lib/actionview/all/actionview_test.rb
+++ b/lib/actionview/all/actionview_test.rb
@@ -11,3 +11,14 @@ rescue ActionView::Template::Error
 rescue ActionView::TemplateError
 rescue ActionView::SyntaxErrorInTemplate
 end
+
+module ActionController
+  class Base
+    include ActionView::Layouts
+
+    def show
+      view_context
+      T.let(view_context.render({}), String)
+    end
+  end
+end


### PR DESCRIPTION
Controllers in Rails have this method called `view_context` that returns an instance of a view context class. The basic view context is `ActionViews::Base`, but this can be configured with the `view_context_class`. The requirements for a view context class are that it can be initialized with three arguments, and that it responds to the `render` method with a `String`.

This change adds an interface for view contexts. A lot of the argument types are currently untyped. I believe they can be filled in later. The main thing this change provides is the proper interface for a view context, and the actual method that returns a view context so that Rails applications can type-check against it.

One question I have: is this the correct way to define an interface for this use case?

Another suggestion that is separate from this PR: when a new gem is added to this repository, it causes a lot of the hidden definitions or auto-generated files in a consuming repository to get blown away. While this makes sense, it does mean that the consuming repository is often left without placeholder method definitions and a lot of method missing type errors ensue. Would it be possible to provide a more additive solution? For example, maybe each directory could contain a `generated.rbi` file that we could remove methods from as we add more robust hand-written type definitions?