### PR TITLE
Added "include T::Enumerable" to fix sorbet/#1871

### DIFF
--- a/lib/bundler/all/bundler.rbi
+++ b/lib/bundler/all/bundler.rbi
@@ -1242,6 +1242,7 @@ class Bundler::Dsl::DSLError < Bundler::GemfileError
 end
 
 class Bundler::EndpointSpecification < Gem::Specification
+  include T::Enumerable
   ILLFORMED_MESSAGE = ::T.let(nil, T.untyped)
 
   sig do


### PR DESCRIPTION
Added "include T::Enumerable" to fix sorbet/#1871.
Also Slack/Sorbet/Discuss: 
https://sorbet-ruby.slack.com/archives/CHN2L03NH/p1569684429135200