### PR TITLE
Improve AS Hash types

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -418,38 +418,6 @@ module ActiveSupport::NumberHelper
   def number_to_rounded(number, locale: :en, precision: 3, significant: false, separator: ".", delimiter: "", strip_insignificant_zeros: false); end
 end
 
-class Hash
-  sig { returns(T.self_type) }
-  def deep_stringify_keys; end
-
-  sig { returns(T.self_type) }
-  def deep_stringify_keys!; end
-
-  sig { returns(T.self_type) }
-  def deep_symbolize_keys; end
-
-  sig { returns(T.self_type) }
-  def deep_symbolize_keys!; end
-
-  sig { returns(T.self_type) }
-  def deep_transform_keys; end
-
-  sig { returns(T.self_type) }
-  def deep_transform_keys!; end
-
-  sig { returns(T.self_type) }
-  def stringify_keys; end
-
-  sig { returns(T.self_type) }
-  def stringify_keys!; end
-
-  sig { returns(T.self_type) }
-  def symbolize_keys; end
-
-  sig { returns(T.self_type) }
-  def symbolize_keys!; end
-end
-
 module ActiveSupport::Inflector
   sig do
     params(
@@ -616,13 +584,34 @@ class Hash
   def stringify_keys; end
 
   sig { returns(T::Hash[String, T.untyped]) }
+  def stringify_keys!; end
+
+  sig { returns(T::Hash[String, T.untyped]) }
   def deep_stringify_keys; end
+
+  sig { returns(T::Hash[String, T.untyped]) }
+  def deep_stringify_keys!; end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def symbolize_keys; end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
+  def symbolize_keys!; end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
   def deep_symbolize_keys; end
+
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def deep_symbolize_keys!; end
+
+  # in an ideal world, `arg` would be the type of all keys, the 1st `T.untyped` would be
+  # the type of keys your block returns, and the 2nd `T.untyped` would be the type of values
+  # that the hash had.
+  sig { params(block: T.proc.params(arg: T.untyped).void).returns(T::Hash[T.untyped, T.untyped]) }
+  def deep_transform_keys(&block); end
+
+  sig { params(block: T.proc.params(arg: T.untyped).void).returns(T::Hash[T.untyped, T.untyped]) }
+  def deep_transform_keys!(&block); end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def to_options; end

--- a/lib/activesupport/all/activesupport_hash_test.rb
+++ b/lib/activesupport/all/activesupport_hash_test.rb
@@ -1,10 +1,36 @@
 # typed: true
 
 module ActiveSupportHashTest
-  h = {a: "1", b: "2"}
-  h.stringify_keys
-  h.symbolize_keys
-  h.deep_stringify_keys
-  h.deep_symbolize_keys
-  h.to_options
+  # this is our initial value
+  h1 = {a: "1", b: "2"}
+  # as far as Sorbet knows, it starts life as a Shape
+  T.assert_type!(h1, {a: String, b: String})
+
+  # this is another initial value
+  h2 = {"a" => 1, "b" => 2}
+  # as far as Sorbet knows, it starts life as a Shape
+  T.assert_type!(h2, {"a" => Integer, "b" => Integer})
+
+  # in an ideal world, `h1.stringify_keys` would return something like:
+  # - { "a" => String, "b" => String }
+  # - T::Hash[String, String]
+  # and `h2.stringify_keys` would return one of:
+  # - { "a" => Integer, "b" => Integer }
+  # - T::Hash[String, Integer]
+  # if you find a way to have Sorbet generically do this, please improve this!
+  T.assert_type!(h1.stringify_keys, T::Hash[String, T.untyped])
+  T.assert_type!(h2.stringify_keys, T::Hash[String, T.untyped])
+  T.assert_type!(h1.symbolize_keys, T::Hash[Symbol, T.untyped])
+  T.assert_type!(h2.symbolize_keys, T::Hash[Symbol, T.untyped])
+
+  # these tests just confirm that methods are defined
+  h1.symbolize_keys!
+  h1.stringify_keys!
+  h1.deep_stringify_keys
+  h1.deep_stringify_keys!
+  h1.deep_symbolize_keys
+  h1.deep_symbolize_keys!
+  h1.deep_transform_keys { |k| k.to_s.upcase }
+  h1.deep_transform_keys! { |k| k.to_s.upcase }
+  h1.to_options
 end


### PR DESCRIPTION
Better attempt at https://github.com/sorbet/sorbet-typed/pull/147

- Removes the types in https://github.com/sorbet/sorbet-typed/pull/100 that returned `T.self_type`. This is incorrect; see comments in that PR for why.
- Replace with types that, where possible, return the correct key type.
- Add many more tests.