### PR TITLE
fix signature for accepts_nested_attributes_for

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -203,7 +203,7 @@ end
 module ActiveRecord::NestedAttributes::ClassMethods
   sig do
     params(
-      attr_names: T.any(T.any(Symbol, String), T::Array[T.any(Symbol, String)]),
+      attr_names: T.any(Symbol, String),
       allow_destroy: T.nilable(T::Boolean),
       reject_if: T.any(Symbol, T.proc.returns(T::Boolean)),
       limit: T.any(Integer, Symbol, T.proc.returns(Integer)),
@@ -211,7 +211,7 @@ module ActiveRecord::NestedAttributes::ClassMethods
     ).void
   end
   def accepts_nested_attributes_for(
-    attr_names,
+    *attr_names,
     allow_destroy: nil,
     reject_if: nil,
     limit: nil,

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -67,6 +67,15 @@ class ActiveRecordCallbacksTest < ApplicationRecord
   after_validation :validation_teardown, on: [:create, :update]
 end
 
+class ActiveRecordNestedAttributeTest < ApplicationRecord
+  # creates avatar_attributes=
+  accepts_nested_attributes_for :avatar, reject_if: proc { |attributes| attributes['name'].blank? }
+  # creates avatar_attributes=
+  accepts_nested_attributes_for :avatar, reject_if: :all_blank
+  # # creates avatar_attributes= and posts_attributes=
+  accepts_nested_attributes_for :avatar, :posts, allow_destroy: true
+end
+
 class ActiveRecordMigrationsTest
   def test_table
     # Hack around the fact that change_table isn't included in the all/activerecord.rbi.


### PR DESCRIPTION
According to the API documentation and source code, this method accept a splash of attr_names
 
https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html#method-i-accepts_nested_attributes_for