### PR TITLE
ActionController::Parameters#keys should take no arguments and return an array

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -97,8 +97,8 @@ class ActionController::Parameters
   sig { params(key: T.any(String, Symbol)).returns(T::Boolean) }
   def key?(key); end
 
-  sig { params(key: T.any(String, Symbol)).returns(T.untyped) }
-  def keys(key); end
+  sig { returns(T.untyped) }
+  def keys; end
 
   sig { params(other_hash: T.untyped).returns(ActionController::Parameters) }
   def merge!(other_hash); end

--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -97,7 +97,7 @@ class ActionController::Parameters
   sig { params(key: T.any(String, Symbol)).returns(T::Boolean) }
   def key?(key); end
 
-  sig { returns(T.untyped) }
+  sig { returns(T::Array[T.untyped]) }
   def keys; end
 
   sig { params(other_hash: T.untyped).returns(ActionController::Parameters) }


### PR DESCRIPTION
```ruby
> ActionController::Parameters.new(foo: 'bar').keys
=> ["foo"]

> ActionController::Parameters.new(foo: 'bar').keys(:foo)
ArgumentError: wrong number of arguments (given 1, expected 0)
```