### PR TITLE
Add sig to Activerecord#==

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -512,6 +512,9 @@ class ActiveRecord::Base
     unless: nil,
     on: nil
   ); end
+
+  sig { params(comparison_object: T.untyped).returns(T::Boolean) }
+  def ==(comparison_object); end
 end
 
 module ActiveRecord::Inheritance::ClassMethods


### PR DESCRIPTION
### Motivation
Currently,
```
./a.rb:2: Revealed type: T.untyped https://srb.help/7014
     2 |T.reveal_type(User.last == User.last)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
I think we should expect it to be revealed as T::Boolean. So I'm creating a PR to add a signature for the `==` method on active-record.

### Test Plan
After the patch,
```
a.rb:2: Revealed type: T::Boolean https://srb.help/7014
     2 |T.reveal_type(User.last == User.last)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```