### PR TITLE
Add Enumerable#index_by

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -657,3 +657,16 @@ class Numeric
   sig { returns(T.self_type) }
   def in_milliseconds; end
 end
+
+module Enumerable
+  # https://github.com/rails/rails/blob/v5.2.3/activesupport/lib/active_support/core_ext/enumerable.rb#L64..L72
+  # the case where a block isn't given isn't handled - that seems like an unlikely case
+  sig do
+    type_parameters(:key).params(
+      block: T.proc.params(o: Enumerable::Elem).returns(T.type_parameter(:key))
+    ).returns(
+      T::Hash[T.type_parameter(:key), Enumerable::Elem]
+    )
+  end
+  def index_by(&block); end
+end

--- a/lib/activesupport/all/activesupport_enumerable_test.rb
+++ b/lib/activesupport/all/activesupport_enumerable_test.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module ActiveSupportEnumerableTest
+  T.assert_type!([1,2,3].index_by(&:odd?), T::Hash[T::Boolean, Integer])
+  T.assert_type!(["hello", "world", "sorbet", "here"].index_by {|s| s.length}, T::Hash[Integer, String])
+end


### PR DESCRIPTION
https://github.com/rails/rails/blob/v5.2.3/activesupport/lib/active_support/core_ext/enumerable.rb#L64..L72 - only handled the case where a block is given.

[sorbet.run example here](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Amodule%20Enumerable%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20do%0A%20%20%20%20type_parameters(%3Akey).params(%0A%20%20%20%20%20%20block%3A%20T.proc.params(o%3A%20Enumerable%3A%3AElem).returns(T.type_parameter(%3Akey))%0A%20%20%20%20).returns(%0A%20%20%20%20%20%20T%3A%3AHash%5BT.type_parameter(%3Akey)%2C%20Enumerable%3A%3AElem%5D%0A%20%20%20%20)%0A%20%20end%0A%20%20def%20index_by(%26block)%0A%20%20%20%20result%20%3D%20%7B%7D%0A%20%20%20%20each%20%7B%20%7Celem%7C%20result%5Bblock.call(elem)%5D%20%3D%20elem%20%7D%0A%20%20%20%20result%0A%20%20end%0Aend%0A%0A%0AT.reveal_type(%5B1%2C2%2C3%5D.index_by(%26%3Aodd%3F)))