### PR TITLE
Add extremely minimal `graphql` types

### DIFF
--- a/lib/graphql/all/graphql.rbi
+++ b/lib/graphql/all/graphql.rbi
@@ -1,0 +1,16 @@
+# typed: true
+
+module GraphQL::Schema::Member::HasFields
+  def field(*args, **kwargs, &block); end
+end
+
+module GraphQL::Schema::Member::HasArguments
+  def argument(*args, **kwargs, &block); end
+end
+
+class GraphQL::Schema::Object < GraphQL::Schema::Member
+  extend GraphQL::Schema::Member::HasFields
+
+  # srb rbi gems does *not* add the next line, which means arguments don't work out of the box
+  extend GraphQL::Schema::Member::HasArguments
+end

--- a/lib/graphql/all/graphql_test.rb
+++ b/lib/graphql/all/graphql_test.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+module GraphqlTest
+  class User < GraphQL::Schema::Object
+  end
+
+  class Query < GraphQL::Schema::Object
+    field :user, User, "The current user", null: true do
+      argument :id, ID, "The ID of the user to find", required: true
+    end
+  end
+end


### PR DESCRIPTION
This is (only just) enough to get you started with https://github.com/rmosolgo/graphql-ruby

The main reason for this is because `srb rbi gems` doesn't include the `GraphQL::Schema::Member::HasArguments` include, which means you can't use arguments out of the box. There's probably other really entry level features that could easily be added here too.