### PR TITLE
Add ActiveSupport::Duration converters

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -670,3 +670,14 @@ module Enumerable
   end
   def index_by(&block); end
 end
+
+class ActiveSupport::Duration
+  sig { returns(Integer) }
+  def to_i; end
+
+  sig { returns(Float) }
+  def to_f; end
+
+  sig { returns(String) }
+  def to_s; end
+end

--- a/lib/activesupport/all/activesupport_duration_test.rb
+++ b/lib/activesupport/all/activesupport_duration_test.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+module ActiveSupportTimesTest
+  T.assert_type!(1.day, ActiveSupport::Duration)
+  T.assert_type!(1.day.to_i, Integer)
+  T.assert_type!(1.day.to_f, Float)
+  T.assert_type!(1.day.to_s, String)
+end


### PR DESCRIPTION
Adds these:

```ruby
$ irb
2.6.3 :001 > require 'active_support/all'
 => true
2.6.3 :002 > 1.day.to_i
 => 86400
2.6.3 :003 > 1.day.to_f
 => 86400.0
2.6.3 :004 > 1.day.to_s
 => "86400"
```