### PR TITLE
Add value method for GraphQL enums.

### DIFF
--- a/lib/graphql/all/graphql.rbi
+++ b/lib/graphql/all/graphql.rbi
@@ -14,3 +14,19 @@ class GraphQL::Schema::Object < GraphQL::Schema::Member
   # srb rbi gems does *not* add the next line, which means arguments don't work out of the box
   extend GraphQL::Schema::Member::HasArguments
 end
+
+class GraphQL::Schema::Enum < GraphQL::Schema::Member
+  # Define a value for this enum
+  #
+  # _@param_ `graphql_name` - the GraphQL value for this, usually `SCREAMING_CASE`
+  #
+  # _@param_ `description` - the GraphQL description for this value, present in documentation
+  #
+  # _@param_ `value` - , the translated Ruby value for this object (defaults to `graphql_name`)
+  #
+  # _@param_ `deprecation_reason` - if this object is deprecated, include a message here
+  #
+  # _@see_ `{Schema::EnumValue}` — which handles these inputs by default
+  sig { params(graphql_name: T.any(String, Symbol), value: Object, description: String, deprecation_reason: String, block: T.untyped).void }
+  def self.value(graphql_name, value: nil, description: nil, deprecation_reason: nil, &block); end
+end

--- a/lib/graphql/all/graphql.rbi
+++ b/lib/graphql/all/graphql.rbi
@@ -12,6 +12,7 @@ class GraphQL::Schema::Object < GraphQL::Schema::Member
   extend GraphQL::Schema::Member::HasFields
 
   # srb rbi gems does *not* add the next line, which means arguments don't work out of the box
+  # Note this isn't strictly correct. see https://github.com/sorbet/sorbet-typed/pull/166
   extend GraphQL::Schema::Member::HasArguments
 end
 

--- a/lib/graphql/all/graphql_test.rb
+++ b/lib/graphql/all/graphql_test.rb
@@ -9,4 +9,12 @@ module GraphqlTest
       argument :id, ID, "The ID of the user to find", required: true
     end
   end
+
+  class CardinalDirectionType < GraphQL::Schema::Enum
+    value "NORTH", value: 'north'
+    value "EAST", value: 'east', description: "Lorem ipsum"
+    value "SOUTH", value: 'south', deprecation_reason: "We just don't like south that much."
+    value "WEST", value: 'west'
+    value "THE_SECRET_DIRECTION" # no value
+  end
 end


### PR DESCRIPTION
Partially generated by Sord, with some modifications.

This is building off of #166.

https://graphql-ruby.org/type_definitions/enums.html