### PR TITLE
`ActiveRecord::Relation` is a class, not a module

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1406,7 +1406,7 @@ module ActiveRecord::Locking::Pessimistic
   def with_lock(lock = nil, &blk); end
 end
 
-module ActiveRecord::Relation
+class ActiveRecord::Relation
   sig { returns(Integer) }
   def delete_all; end
 end


### PR DESCRIPTION
fixes a bug in https://github.com/sorbet/sorbet-typed/pull/164