### PR TITLE
Make `Rails.root` non-nilable

### DIFF
--- a/lib/railties/all/railties.rbi
+++ b/lib/railties/all/railties.rbi
@@ -4,7 +4,7 @@ module Rails
   sig {returns(Rails::Application)}
   def self.application; end
   
-  sig { returns(T.nilable(Pathname)) }
+  sig { returns(Pathname) }
   def self.root; end
 end
 


### PR DESCRIPTION
See https://github.com/sorbet/sorbet-typed/pull/150#issuecomment-541926418

Theoretically `Rails.root` can return `nil`, if `Rails.application` is nil. But I think that's so unlikely that it's not worth considering here, because:

1) We have made `Rails.application` not nilable immediately above this.
2) The only scenario I think `Rails.application` might be nil are if you're running a rails app via bundler-inline (ie. using one of [these](https://github.com/rails/rails/tree/master/guides/bug_report_templates)), but I can't see why you'd want Sorbet in such a scenario.

Without this change, every call to `Rails.root` in a `typed: true` app requires `T.must`, which gets pretty annoying.

Happy to be reverted if there's scenarios I'm missing.