### PR TITLE
Fix Open3 opt types

### DIFF
--- a/lib/ruby/all/open3.rbi
+++ b/lib/ruby/all/open3.rbi
@@ -4,7 +4,7 @@ module Open3
   sig do
     params(
       cmd: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped],
+      opts: T.untyped,
       block: T.nilable(T.proc.params(stdin: IO, stdout: IO, stderr: IO, wait_thr: Process::Waiter).void)
     ).returns([IO, IO, IO, Process::Waiter])
   end
@@ -13,7 +13,7 @@ module Open3
   sig do
     params(
       cmd: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped],
+      opts: T.untyped,
       block: T.nilable(T.proc.params(stdin: IO, stdout: IO, wait_thr: Process::Waiter).void)
     ).returns([IO, IO, Process::Waiter])
   end
@@ -22,7 +22,7 @@ module Open3
   sig do
     params(
       cmd: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped],
+      opts: T.untyped,
       block: T.nilable(T.proc.params(stdin: IO, stdout_and_stderr: IO, wait_thr: Process::Waiter).void)
     ).returns([IO, IO, Process::Waiter])
   end
@@ -61,7 +61,7 @@ module Open3
   sig do
     params(
       cmds: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped],
+      opts: T.untyped,
       block: T.nilable(T.proc.params(first_stdin: IO, last_stdout: IO, wait_threads: T::Array[Process::Waiter]).void)
     ).returns([IO, IO, T::Array[Process::Waiter]])
   end
@@ -70,7 +70,7 @@ module Open3
   sig do
     params(
       cmds: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped],
+      opts: T.untyped,
       block: T.nilable(T.proc.params(last_stdout: IO, wait_threads: T::Array[Process::Waiter]).void)
     ).returns([IO, T::Array[Process::Waiter]])
   end
@@ -79,7 +79,7 @@ module Open3
   sig do
     params(
       cmds: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped],
+      opts: T.untyped,
       block: T.nilable(T.proc.params(first_stdin: IO, wait_threads: T::Array[Process::Waiter]).void)
     ).returns([IO, T::Array[Process::Waiter]])
   end
@@ -88,7 +88,7 @@ module Open3
   sig do
     params(
       cmds: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped],
+      opts: T.untyped,
       block: T.nilable(T.proc.params(wait_threads: T::Array[Process::Waiter]).void)
     ).returns(T::Array[Process::Waiter])
   end
@@ -97,7 +97,7 @@ module Open3
   sig do
     params(
       cmds: T.any(String, T::Array[String]),
-      opts: T::Hash[Symbol, T.untyped]
+      opts: T.untyped
     ).returns(T::Array[Process::Status])
   end
   def self.pipeline(*cmds, **opts); end


### PR DESCRIPTION
The type of the `opt` argument in `Open3` methods is incorrectly `T::Hash[Symbol, T.untyped]`. The `T::Hash` part of the type for double-splat arguments is implied, so the type should be simply `T.untyped`.