### PR TITLE
Add definitions for `end_of_day` and its alias `at_end_of_day`

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -537,6 +537,12 @@ class ActiveSupport::TimeWithZone
 
   sig { returns(ActiveSupport::TimeWithZone) }
   def at_middle_of_day; end
+
+  sig { returns(ActiveSupport::TimeWithZone) }
+  def end_of_day; end
+
+  sig { returns(ActiveSupport::TimeWithZone) }
+  def at_end_of_day; end
 end
 
 # defines some of the methods at https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/date


### PR DESCRIPTION
Adds definitions for `end_of_day` and its alias `at_end_of_day` for `ActiveSupport::TimeWithZone` from https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/time/calculations.rb#L219