### PR TITLE
Add a skeleton type signature for HashWithIndifferentAccess

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -873,9 +873,9 @@ class ActiveSupport::HashWithIndifferentAccess < Hash
   include Enumerable
 
   extend T::Generic
-  K = type_member(:out)
-  V = type_member(:out)
-  Elem = type_member(:out)
+  K = type_member
+  V = type_member
+  Elem = type_member
 
   sig { params(key: T.any(String, Symbol)).returns(T.untyped) }
   def [](key); end
@@ -974,7 +974,7 @@ class ActiveSupport::HashWithIndifferentAccess < Hash
   # Same as `Hash#fetch` where the key passed as argument can be
   # either a string or a symbol:
   #
-  # ```
+  # ```ruby
   # counters = ActiveSupport::HashWithIndifferentAccess.new
   # counters[:foo] = 1
   #
@@ -1000,8 +1000,8 @@ class ActiveSupport::HashWithIndifferentAccess < Hash
   sig { params(indices: T.any(String, Symbol), block: T.untyped).returns(T.untyped) }
   def fetch_values(*indices, &block); end
 
-  sig { params(constructor: T.untyped).void }
-  def initialize(constructor = {}); end
+  sig { params(constructor: T.untyped, block: T.untyped).void }
+  def initialize(constructor = {}, &block); end
 
   # Checks the hash for a key matching the argument passed in:
   #


### PR DESCRIPTION
This adds a basic type signature for [`HashWithIndifferentAccess`](https://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html), which is a Rails class that descends from `Hash`, but with the ability to access hash members via either String or Symbol keys.

See also `hash_with_indifferent_access.rb`: https://github.com/rails/rails/blob/f33d52c95217212cbacc8d5e44b5a8e3cdc6f5b3/activesupport/lib/active_support/hash_with_indifferent_access.rb

It only uses enough of the generics system to pass typechecking, so it doesn't really have fully correct type signatures yet. I still need to add tests as well.