### PR TITLE
Normalized string singularize to Inflector.singularize.

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -189,7 +189,7 @@ class String
   sig { returns(T.untyped) }
   def safe_constantize; end
 
-  sig { params(locale: Symbol).returns(T.nilable(String)) }
+  sig { params(locale: Symbol).returns(String) }
   def singularize(locale = :en); end
 
   sig { returns(T.untyped) }


### PR DESCRIPTION
String.singularize is implemented in terms of Inflector.singularize and so their signatures should be equal.