### PR TITLE
Missing ClassMethods mix-in

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -16,6 +16,8 @@ module ActiveModel::Dirty
 end
 
 module ActiveModel::Validations
+  mixes_in_class_methods(ClassMethods)
+
   module ClassMethods
     # https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations.rb#L136-L154
     sig do


### PR DESCRIPTION
Fixes the following code:

```
class MyClass
  include ActiveModel::Validations

  validate :my_validator
end
```

Before this fix, Sorbet doesn't know that `validate` is a valid class-method.