### PR TITLE
Fix ActiveRecord `save` sigs

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -584,7 +584,7 @@ module ActiveRecord::Persistence
   sig do
     params(
       args: T.untyped,
-      blk: T.proc.void,
+      blk: T.nilable(T.proc.void),
     ).returns(TrueClass)
   end
   def save!(*args, &blk); end
@@ -592,7 +592,7 @@ module ActiveRecord::Persistence
   sig do
     params(
       args: T.untyped,
-      blk: T.proc.void,
+      blk: T.nilable(T.proc.void),
     ).returns(T::Boolean)
   end
   def save(*args, &blk); end
@@ -913,12 +913,6 @@ module ActiveRecord::Validations
   include ActiveModel::Validations
 
   mixes_in_class_methods(ActiveModel::Validations::ClassMethods)
-
-  sig { params(options: T.untyped).returns(T::Boolean) }
-  def save(options = nil); end
-
-  sig { params(options: T.untyped).returns(TrueClass) }
-  def save!(options = nil); end
 end
 
 # Represents the schema of an SQL table in an abstract way. This class

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -65,6 +65,16 @@ class ActiveRecordCallbacksTest < ApplicationRecord
   before_validation :validation_setup, on: :create
   after_validation :validation_teardown
   after_validation :validation_teardown, on: [:create, :update]
+
+  def do_the_thing
+    if new_record? || persisted?
+      save
+      save(validate: false, touch: false)
+      save!
+      touch
+      update!(did_the_thing: true)
+    end
+  end
 end
 
 class ActiveRecordMigrationsTest


### PR DESCRIPTION
- Remove two sigs for the same method, added in https://github.com/sorbet/sorbet-typed/pull/153 and https://github.com/sorbet/sorbet-typed/pull/38
- Make the block arg optional
- Add some tests for some AR::Base instance methods