### PR TITLE
Date#- should work with AS::Duration

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -550,6 +550,16 @@ end
 class Date
   sig { params(options: T::Hash[Symbol, Integer]).returns(Date) }
   def advance(options); end
+
+  # these are the sigs for Date- in the stdlib
+  # https://github.com/sorbet/sorbet/blob/3910f6cfd9935c9b42e2135e32e15ab8a6e5b9be/rbi/stdlib/date.rbi#L373
+  # note that if more sigs are added to sorbet you should replicate them here
+  # check sorbet master: https://github.com/sorbet/sorbet/blob/master/rbi/stdlib/date.rbi
+  sig {params(arg0: Numeric).returns(T.self_type)}
+  sig {params(arg0: Date).returns(Rational)}
+  # these sigs are added for activesupport users
+  sig {params(arg0: ActiveSupport::Duration).returns(T.self_type)}
+  def -(arg0); end
 end
 
 # defines some of the methods at https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/time

--- a/lib/activesupport/all/activesupport_duration_test.rb
+++ b/lib/activesupport/all/activesupport_duration_test.rb
@@ -63,5 +63,8 @@ module ActiveSupportDurationTest
   T.assert_type!(3.years % 5, ActiveSupport::Duration)
   T.assert_type!(3.years % 5.days, ActiveSupport::Duration)
 
+  # see https://github.com/sorbet/sorbet-typed/pull/190
   T.assert_type!(Date.today - 4.weeks, Date)
+  T.assert_type!(Date.today - Date.today, Rational)
+  T.assert_type!(Date.today - 4, Date)
 end

--- a/lib/activesupport/all/activesupport_duration_test.rb
+++ b/lib/activesupport/all/activesupport_duration_test.rb
@@ -37,7 +37,7 @@ module ActiveSupportDurationTest
   T.assert_type!(ActiveSupport::Duration.build(123456), ActiveSupport::Duration)
 
   # For example, "P3Y6M4DT12H30M5S" represents a duration of "three years, six
-  # months, four days, twelve hours, thirty minutes, and five seconds". 
+  # months, four days, twelve hours, thirty minutes, and five seconds".
   T.assert_type!(ActiveSupport::Duration.parse("P3Y6M4DT12H30M5S"), ActiveSupport::Duration)
 
   T.assert_type!(2.years.eql?(123), T::Boolean)
@@ -62,4 +62,6 @@ module ActiveSupportDurationTest
 
   T.assert_type!(3.years % 5, ActiveSupport::Duration)
   T.assert_type!(3.years % 5.days, ActiveSupport::Duration)
+
+  T.assert_type!(Date.today - 4.weeks, Date)
 end


### PR DESCRIPTION
There's been a bunch of improvements to the sig for `Date#-` recently: https://github.com/sorbet/sorbet/pull/2514 https://github.com/sorbet/sorbet/pull/2539 https://github.com/sorbet/sorbet/pull/2567 https://github.com/sorbet/sorbet/pull/2570

This PR adds one more sig, for subtracting an `ActiveSupport::Duration`. Annoyingly ActiveSupport::Duration is not a subclass of `Numeric` even though it more or less behaves like one. So the sigs included in sorbet didn't work anymore.

@elliottt @aisamanra FYI, tagging you since you both made improvements to the `Date#-` sigs (thank you!).