### PR TITLE
Add delayed_job

### DIFF
--- a/lib/delayed_job/all/delayed_job.rbi
+++ b/lib/delayed_job/all/delayed_job.rbi
@@ -1,0 +1,12 @@
+# typed: strong
+
+module Delayed::MessageSending
+  extend T::Sig
+
+  sig { params(options: T.nilable(T::Hash[Symbol, T.untyped])).returns(T.self_type) }
+  def delay(options = nil); end
+end
+
+class Object
+  include Delayed::MessageSending
+end

--- a/lib/delayed_job/all/delayed_job_test.rb
+++ b/lib/delayed_job/all/delayed_job_test.rb
@@ -1,0 +1,33 @@
+# typed: true
+
+module DelayedJobTest
+  class A
+    extend T::Sig
+
+    sig { void }
+    def foo
+      # do something
+    end
+
+    sig { params(baz: Integer).void }
+    def bar(baz)
+      # do something else
+    end
+
+    sig { params(n: Integer).void }
+    def self.foobar(n = 1)
+    end
+  end
+
+  # confirm the sigs work fine without delay
+  A.new.foo
+  A.new.bar(1)
+  A.foobar
+  A.foobar(1)
+
+  # the real tests
+  A.new.delay.foo
+  A.new.delay(priority: 1).bar(1)
+  A.delay(priority: 1).foobar
+  A.delay.foobar(1)
+end


### PR DESCRIPTION
[`delayed_job`](https://github.com/collectiveidea/delayed_job) adds a `.delay` method to all Objects. This method creates a [proxy](https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/message_sending.rb#L2..L19) on which you call the actual method you want to have performed in a background process.

eg. `Mailer.delay.send_email_in_separate_processs`

This PR adds a sig which tells sorbet that `delay` returns `T.self_type`. This isn't strictly true - technically it returns a `Delayed::DelayProxy` which uses `method_missing` to queue jobs. But in practice it is helpful for ensuring that you are calling methods that exist with the right arguments etc.

The main weakness of this approach is that it doesn't prevent you from doing things like `foo = A.delay.do_something`. In practice `foo` will *not* be the return value of `do_something`, but I don't think it's possible to tell Sorbet that.