### PR TITLE
Refine `Time#in_time_zone` and `String#in_time_zone` sigs

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -154,6 +154,7 @@ class String
   def humanize(capitalize: true, keep_id_suffix: false); end
 
   sig { params(zone: String).returns(T.any(Time, ActiveSupport::TimeWithZone)) }
+  sig { params(zone: NilClass).returns(Time) }
   def in_time_zone(zone = ::Time.zone); end
 
   sig { params(amount: Integer, indent_string: T.nilable(String), indent_empty_lines: T::Boolean).returns(T.nilable(String)) }
@@ -590,6 +591,7 @@ class Time
 
   # https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
   sig { params(zone: String).returns(T.any(Time, ActiveSupport::TimeWithZone)) }
+  sig { params(zone: NilClass).returns(Time) }
   def in_time_zone(zone = ::Time.zone); end
 end
 

--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -153,7 +153,7 @@ class String
   sig { params(capitalize: T::Boolean, keep_id_suffix: T::Boolean).returns(String) }
   def humanize(capitalize: true, keep_id_suffix: false); end
 
-  sig { params(zone: String).returns(T.any(Time, ActiveSupport::TimeWithZone)) }
+  sig { params(zone: T.any(String, ActiveSupport::TimeZone)).returns(ActiveSupport::TimeWithZone) }
   sig { params(zone: NilClass).returns(Time) }
   def in_time_zone(zone = ::Time.zone); end
 
@@ -590,7 +590,7 @@ class Time
   def at_middle_of_day; end
 
   # https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
-  sig { params(zone: String).returns(T.any(Time, ActiveSupport::TimeWithZone)) }
+  sig { params(zone: T.any(String, ActiveSupport::TimeZone)).returns(ActiveSupport::TimeWithZone) }
   sig { params(zone: NilClass).returns(Time) }
   def in_time_zone(zone = ::Time.zone); end
 end

--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -153,8 +153,8 @@ class String
   sig { params(capitalize: T::Boolean, keep_id_suffix: T::Boolean).returns(String) }
   def humanize(capitalize: true, keep_id_suffix: false); end
 
-  sig { params(zone: T.any(String, ActiveSupport::TimeZone)).returns(ActiveSupport::TimeWithZone) }
-  sig { params(zone: NilClass).returns(Time) }
+  # returns Time in the case zone is passed nil and ActiveSupport::TimeWithZone otherwise
+  sig { params(zone: T.nilable(T.any(String, ActiveSupport::TimeZone))).returns(T.any(ActiveSupport::TimeWithZone, Time)) }
   def in_time_zone(zone = ::Time.zone); end
 
   sig { params(amount: Integer, indent_string: T.nilable(String), indent_empty_lines: T::Boolean).returns(T.nilable(String)) }
@@ -590,8 +590,8 @@ class Time
   def at_middle_of_day; end
 
   # https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
-  sig { params(zone: T.any(String, ActiveSupport::TimeZone)).returns(ActiveSupport::TimeWithZone) }
-  sig { params(zone: NilClass).returns(Time) }
+  # returns Time in the case zone is passed nil and ActiveSupport::TimeWithZone otherwise
+  sig { params(zone: T.nilable(T.any(String, ActiveSupport::TimeZone))).returns(T.any(ActiveSupport::TimeWithZone, Time)) }
   def in_time_zone(zone = ::Time.zone); end
 end
 

--- a/lib/activesupport/all/activesupport_times_test.rb
+++ b/lib/activesupport/all/activesupport_times_test.rb
@@ -4,4 +4,7 @@ module ActiveSupportTimesTest
   Time.now.midnight
   Time.now.in_time_zone.midnight
   Time.now.in_time_zone("Paris").midnight
+  Time.now.in_time_zone(nil).midnight
+
+  Time.now.to_s.in_time_zone(nil).midnight
 end

--- a/lib/activesupport/all/activesupport_times_test.rb
+++ b/lib/activesupport/all/activesupport_times_test.rb
@@ -4,7 +4,9 @@ module ActiveSupportTimesTest
   Time.now.midnight
   Time.now.in_time_zone.midnight
   Time.now.in_time_zone("Paris").midnight
+  Time.now.in_time_zone(ActiveSupport::TimeZone["Paris"])
   Time.now.in_time_zone(nil).midnight
 
+  Time.now.to_s.in_time_zone(ActiveSupport::TimeZone["Paris"]).midnight
   Time.now.to_s.in_time_zone(nil).midnight
 end

--- a/lib/activesupport/all/activesupport_times_test.rb
+++ b/lib/activesupport/all/activesupport_times_test.rb
@@ -7,6 +7,8 @@ module ActiveSupportTimesTest
   Time.now.in_time_zone(ActiveSupport::TimeZone["Paris"])
   Time.now.in_time_zone(nil).midnight
 
+  Time.now.to_s.in_time_zone.midnight
+  Time.now.to_s.in_time_zone("Paris").midnight
   Time.now.to_s.in_time_zone(ActiveSupport::TimeZone["Paris"]).midnight
   Time.now.to_s.in_time_zone(nil).midnight
 end


### PR DESCRIPTION
`in_time_zone` on the `Time` and `String` classes allow `nil` to be passed as an argument for `zone`

```ruby
# returns a Time object
Time.now.in_time_zone(nil)
# => 2020-02-02 11:30:51 +0000
```
```ruby
# returns a Time object
Time.now.to_s.in_time_zone(nil)
# => 2020-02-02 11:32:10 +0000
```

Additionally updated the signatures to accept ~either~ an `ActiveSupport::TimeZone` ~or a `String` and updated their return types to be strictly `ActiveSupport::TimeWithZone`. This is because `Time` is only returned in the case `nil` is passed.~

I'm not too sure what the go is when it comes to multiple signatures in RBI files but let me know if there are any issues! Cheers :)