### PR TITLE
Add the `prepend` option to ActiveRecord's `before_destroy`

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -460,13 +460,15 @@ class ActiveRecord::Base
     params(
       arg: T.nilable(Symbol),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      prepend: T.nilable(T::Boolean)
     ).void
   end
   def self.before_destroy(
     arg = nil,
     if: nil,
-    unless: nil
+    unless: nil,
+    prepend: nil
   ); end
 
   sig do

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -44,7 +44,7 @@ class ActiveRecordCallbacksTest < ApplicationRecord
   around_save :log_save_action
   after_save :log_save_action
 
-  before_destroy :log_destroy_action
+  before_destroy :log_destroy_action, prepend: true
   around_destroy :log_destroy_action
   after_destroy :log_destroy_action
 


### PR DESCRIPTION
Documented here: https://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html

This has been around since Rails 3, so adding to the "all" version