### PR TITLE
Make ActiveRecord before_destroy `prepend` keyword default false

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -461,14 +461,14 @@ class ActiveRecord::Base
       arg: T.nilable(Symbol),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      prepend: T.nilable(T::Boolean)
+      prepend: T::Boolean
     ).void
   end
   def self.before_destroy(
     arg = nil,
     if: nil,
     unless: nil,
-    prepend: nil
+    prepend: false
   ); end
 
   sig do


### PR DESCRIPTION
Technically nil is accepted by Rails (which coerces it to false) but I can't
think of any good reason why the caller would want to pass nil.

Follow up to: https://github.com/sorbet/sorbet-typed/pull/201