### PR TITLE
Add signature for ::transaction

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -238,6 +238,10 @@ module ActiveRecord::Inheritance
   mixes_in_class_methods(ActiveRecord::Inheritance::ClassMethods)
 end
 
+module ActiveRecord::Transactions
+  mixes_in_class_methods(ActiveRecord::Transactions::ClassMethods)
+end
+
 class ActiveRecord::Base
   extend ActiveModel::Naming
 
@@ -522,6 +526,16 @@ module ActiveRecord::Inheritance::ClassMethods
 
   sig { returns(T::Boolean) }
   def abstract_class; end
+end
+
+module ActiveRecord::Transactions::ClassMethods
+  sig do
+    params(
+      options: T.nilable(T::Hash[T.any(Symbol, String), T.untyped]),
+      block: T.proc.returns(T.untyped)
+    ).returns(T.untyped)
+  end
+  def transaction(options = {}, &block); end
 end
 
 module ActiveRecord::Persistence

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -155,4 +155,12 @@ class ActiveRecordMigrationsTest
 
     t.index [:foo, :bar], name: "index_foo_bar", unique: true
   end
+
+  def test_transactions
+    ActiveRecordCallbacksTest.transaction do
+    end
+
+    ActiveRecordCallbacksTest.transaction(requires_new: true) do
+    end
+  end
 end


### PR DESCRIPTION
Creating a database transaction results in a sorbet error: 

```ruby
ActiveRecordCallbacksTest.transaction do
end
```

```
lib/activerecord/all/activerecord_test.rb:160: Method transaction does not exist on T.class_of(ActiveRecordCallbacksTest) https://srb.help/7003
     160 |    ActiveRecordCallbacksTest.transaction do
     161 |    end
```