### PR TITLE
Define missing ActionView constants

### DIFF
--- a/lib/actionview/all/actionview.rbi
+++ b/lib/actionview/all/actionview.rbi
@@ -289,9 +289,10 @@ end
 module ActionView::Layouts
   extend T::Helpers
 
-  module ClassMethods; end
-
   mixes_in_class_methods(ActionView::Layouts::ClassMethods)
+end
+
+module ActionView::Layouts::ClassMethods
 end
 
 module ActionView::Rendering
@@ -300,8 +301,14 @@ module ActionView::Rendering
   mixes_in_class_methods(ActionView::Rendering::ClassMethods)
 end
 
+module ActionView::Rendering::ClassMethods
+end
+
 module ActionView::ViewPaths
   extend T::Helpers
 
   mixes_in_class_methods(ActionView::ViewPaths::ClassMethods)
+end
+
+module ActionView::ViewPaths::ClassMethods
 end


### PR DESCRIPTION
```
sorbet/rbi/sorbet-typed/lib/actionview/all/actionview.rbi:313: Unable to resolve constant ClassMethods https://srb.help/5002
     313 |  mixes_in_class_methods(ActionView::ViewPaths::ClassMethods)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

These constants aren't defined within the RBI file, so when used in an
application that doesn't include all of ActionView they aren't defined
at all and cause a sorbet failure.

I'm not sure how to reproduce this in a test, so let me know if you have an idea.