### PR TITLE
Allow values for custom validators in ActiveModel to be anything.

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -69,7 +69,7 @@ module ActiveModel::Validations
         strict: T::Boolean,
         uniqueness: T.any(T::Boolean, T::Hash[T.untyped, T.untyped]),
         unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-        kwargs: T.any(T::Boolean, T::Hash[T.untyped, T.untyped])
+        kwargs: T.untyped
       ).void
     end
     def validates(

--- a/lib/activemodel/all/activemodel_test.rb
+++ b/lib/activemodel/all/activemodel_test.rb
@@ -40,8 +40,12 @@ module ActiveModelTest
 
   validates :card_number, presence: true, if: :paid_with_card?
 
+  # Allow custom validators to be added from other gems.
   validates :custom_validator, foo: true
   validates :custom_validator, foo: { option: 1 }
+  validates :custom_validator, foo: ['bar']
+  validates :custom_validator, foo: 'bar'
+  validates :custom_validator, foo: :bar
 
   # TODO: These are valid but currently fail typechecking.
   # validates :password, confirmation: true, unless: Proc.new { |a| a.password.blank? }


### PR DESCRIPTION
Replace the specific signature with untyped.

Improves on #205.

In my app I have a validator that looks like this, but the array wasn't being accepted by the type signature for kwargs:

```ruby
validates :cover, {
  attached: false,
  content_type: ['image/png', 'image/jpg', 'image/jpeg'],
  size: { less_than: 4.megabytes }
}
```

I'm fairly certain you can pass essentially anything to custom validators, so I've set `kwargs` to `T.untyped`.