### PR TITLE
Fix broken master due to state_machine failure

### DIFF
--- a/lib/state_machines/all/state_machines_test.rb
+++ b/lib/state_machines/all/state_machines_test.rb
@@ -2,6 +2,7 @@
 
 class SomeObject
   extend StateMachines::MacroMethods
+  extend T::Sig
 
   STATES = T.let([
     STATE_A = 'A',


### PR DESCRIPTION
I'm not sure why this started failing in master.

My guess is probably that the recent flatten change caught this.