### PR TITLE
Add RBI for pg_search gem

### DIFF
--- a/lib/pg_search/all/pg_search.rbi
+++ b/lib/pg_search/all/pg_search.rbi
@@ -1,0 +1,45 @@
+# typed: strong
+
+module PgSearch::Model
+  mixes_in_class_methods(PgSearch::Model::ClassMethods)
+end
+
+module PgSearch::Model::ClassMethods
+  sig do
+    params(
+      against: T.any(Symbol, T::Array[Symbol]),
+      if: T.any(Symbol, T.proc.returns(T::Boolean)),
+      update_if: T.any(Symbol, T.proc.returns(T::Boolean)),
+      additional_attributes: T.proc.params(arg0: T.untyped).returns(T::Hash[T.untyped, T.untyped])
+    ).void
+  end
+  def multisearchable(
+    against: T.unsafe(nil),
+    if: T.unsafe(nil),
+    update_if: T.unsafe(nil),
+    additional_attributes: T.unsafe(nil)
+  ); end
+
+  sig do
+    params(
+      name: Symbol,
+      options: T.untyped,
+      against: T.any(Symbol, T::Array[Symbol], T::Hash[T.untyped, T.untyped]),
+      associated_against: T::Hash[T.untyped, T.untyped],
+      using: T.any(Symbol, T::Array[Symbol], T::Hash[T.untyped, T.untyped]),
+      ignoring: T.any(Symbol),
+      ranked_by: String,
+      order_within_rank: String
+    ).void
+  end
+  def pg_search_scope(
+    name,
+    options,
+    against: T.unsafe(nil),
+    associated_against: T.unsafe(nil),
+    using: T.unsafe(nil),
+    ignoring: T.unsafe(nil),
+    ranked_by: T.unsafe(nil),
+    order_within_rank: T.unsafe(nil)
+  ); end
+end

--- a/lib/pg_search/all/pg_search_test.rb
+++ b/lib/pg_search/all/pg_search_test.rb
@@ -1,0 +1,43 @@
+# typed: true
+
+class PgSearchTest
+  include PgSearch::Model
+
+  multisearchable against: [:body], update_if: :body_changed?
+  multisearchable against: :body, update_if: :body_changed?
+  multisearchable against: [:title, :body],
+    additional_attributes: -> (article) { { author_id: article.author_id } }
+
+  pg_search_scope :search_by_title, against: :title
+  pg_search_scope :search_by_full_name, against: [:first_name, :last_name]
+  pg_search_scope :search_by_name, lambda { |name_part, query|
+    raise ArgumentError unless [:first, :last].include?(name_part)
+    {
+      against: name_part,
+      query: query
+    }
+  }
+
+  pg_search_scope :tasty_search, associated_against: {
+    cheeses: [:kind, :brand],
+    cracker: :kind
+  }
+
+  pg_search_scope :search_name, against: :name, using: [:tsearch, :trigram, :dmetaphone]
+  pg_search_scope :search_full_text,
+    against: {
+      title: 'A',
+      subtitle: 'B',
+      content: 'C'
+    }
+
+  pg_search_scope :whose_name_starts_with,
+    against: :name,
+    using: {
+      tsearch: { prefix: true }
+    }
+
+  pg_search_scope :kinda_spelled_like,
+    against: :name,
+    using: :trigram
+end


### PR DESCRIPTION
https://github.com/Casecommons/pg_search

The two most common methods are `multisearchable` and `pg_search_scope`, add
signatures for them as well as tests.