### PR TITLE
Add has_one_attached and has_many_attached methods for ActiveStorage.

### DIFF
--- a/lib/activestorage/<=6.1/activestorage.rbi
+++ b/lib/activestorage/<=6.1/activestorage.rbi
@@ -1,0 +1,75 @@
+# typed: strong
+
+module ActiveStorage::Attached::Model::ClassMethods
+  # Specifies the relation between a single attachment and the model.
+  #
+  # ```ruby
+  # class User < ApplicationRecord
+  #   has_one_attached :avatar
+  # end
+  # ```
+  #
+  # There is no column defined on the model side, Active Storage takes
+  # care of the mapping between your records and the attachment.
+  #
+  # To avoid N+1 queries, you can include the attached blobs in your query like so:
+  #
+  # ```ruby
+  # User.with_attached_avatar
+  # ```
+  #
+  # Under the covers, this relationship is implemented as a `has_one` association to a
+  # ActiveStorage::Attachment record and a `has_one-through` association to a
+  # ActiveStorage::Blob record. These associations are available as `avatar_attachment`
+  # and `avatar_blob`. But you shouldn't need to work with these associations directly in
+  # most circumstances.
+  #
+  # The system has been designed to having you go through the ActiveStorage::Attached::One
+  # proxy that provides the dynamic proxy to the associations and factory methods, like `attach`.
+  #
+  # If the `:dependent` option isn't set, the attachment will be purged
+  # (i.e. destroyed) whenever the record is destroyed.
+  sig do
+    params(
+      name: Symbol,
+      dependent: Symbol
+    ).void
+  end
+  def has_one_attached(name, dependent: :purge_later); end
+
+  # Specifies the relation between multiple attachments and the model.
+  #
+  # ```ruby
+  # class Gallery < ApplicationRecord
+  #   has_many_attached :photos
+  # end
+  # ```
+  #
+  # There are no columns defined on the model side, Active Storage takes
+  # care of the mapping between your records and the attachments.
+  #
+  # To avoid N+1 queries, you can include the attached blobs in your query like so:
+  #
+  # ```ruby
+  # Gallery.where(user: Current.user).with_attached_photos
+  # ```
+  #
+  # Under the covers, this relationship is implemented as a `has_many` association to a
+  # ActiveStorage::Attachment record and a `has_many-through` association to a
+  # ActiveStorage::Blob record. These associations are available as `photos_attachments`
+  # and `photos_blobs`. But you shouldn't need to work with these associations directly in
+  # most circumstances.
+  #
+  # The system has been designed to having you go through the ActiveStorage::Attached::Many
+  # proxy that provides the dynamic proxy to the associations and factory methods, like `#attach`.
+  #
+  # If the `:dependent` option isn't set, all the attachments will be purged
+  # (i.e. destroyed) whenever the record is destroyed.
+  sig do
+    params(
+      name: Symbol,
+      dependent: Symbol
+    ).void
+  end
+  def has_many_attached(name, dependent: :purge_later); end
+end

--- a/lib/activestorage/>=6.1/activestorage.rbi
+++ b/lib/activestorage/>=6.1/activestorage.rbi
@@ -1,0 +1,95 @@
+# typed: strong
+
+module ActiveStorage::Attached::Model::ClassMethods
+  # Specifies the relation between a single attachment and the model.
+  #
+  # ```ruby
+  # class User < ApplicationRecord
+  #   has_one_attached :avatar
+  # end
+  # ```
+  #
+  # There is no column defined on the model side, Active Storage takes
+  # care of the mapping between your records and the attachment.
+  #
+  # To avoid N+1 queries, you can include the attached blobs in your query like so:
+  #
+  # ```ruby
+  # User.with_attached_avatar
+  # ```
+  #
+  # Under the covers, this relationship is implemented as a `has_one` association to a
+  # ActiveStorage::Attachment record and a `has_one-through` association to a
+  # ActiveStorage::Blob record. These associations are available as `avatar_attachment`
+  # and `avatar_blob`. But you shouldn't need to work with these associations directly in
+  # most circumstances.
+  #
+  # The system has been designed to having you go through the ActiveStorage::Attached::One
+  # proxy that provides the dynamic proxy to the associations and factory methods, like `attach`.
+  #
+  # If the `:dependent` option isn't set, the attachment will be purged
+  # (i.e. destroyed) whenever the record is destroyed.
+  #
+  # If you need the attachment to use a service which differs from the globally configured one,
+  # pass the `:service` option. For instance:
+  #
+  # ```ruby
+  # class User < ActiveRecord::Base
+  #   has_one_attached :avatar, service: :s3
+  # end
+  # ```
+  sig do
+    params(
+      name: Symbol,
+      dependent: Symbol,
+      service: T.untyped
+    ).void
+  end
+  def has_one_attached(name, dependent: :purge_later, service: nil); end
+
+  # Specifies the relation between multiple attachments and the model.
+  #
+  # ```ruby
+  # class Gallery < ApplicationRecord
+  #   has_many_attached :photos
+  # end
+  # ```
+  #
+  # There are no columns defined on the model side, Active Storage takes
+  # care of the mapping between your records and the attachments.
+  #
+  # To avoid N+1 queries, you can include the attached blobs in your query like so:
+  #
+  # ```ruby
+  # Gallery.where(user: Current.user).with_attached_photos
+  # ```
+  #
+  # Under the covers, this relationship is implemented as a `has_many` association to a
+  # ActiveStorage::Attachment record and a `has_many-through` association to a
+  # ActiveStorage::Blob record. These associations are available as `photos_attachments`
+  # and `photos_blobs`. But you shouldn't need to work with these associations directly in
+  # most circumstances.
+  #
+  # The system has been designed to having you go through the ActiveStorage::Attached::Many
+  # proxy that provides the dynamic proxy to the associations and factory methods, like `#attach`.
+  #
+  # If the `:dependent` option isn't set, all the attachments will be purged
+  # (i.e. destroyed) whenever the record is destroyed.
+  #
+  # If you need the attachment to use a service which differs from the globally configured one,
+  # pass the `:service` option. For instance:
+  #
+  # ```ruby
+  # class Gallery < ActiveRecord::Base
+  #   has_many_attached :photos, service: :s3
+  # end
+  # ```
+  sig do
+    params(
+      name: Symbol,
+      dependent: Symbol,
+      service: T.untyped
+    ).void
+  end
+  def has_many_attached(name, dependent: :purge_later, service: nil); end
+end

--- a/lib/activestorage/all/activestorage.rbi
+++ b/lib/activestorage/all/activestorage.rbi
@@ -164,3 +164,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   include ActiveStorage::Blob::Identifiable
   include ActiveStorage::Blob::Representable
 end
+
+module ActiveStorage::Attached::Model
+  mixes_in_class_methods(ActiveStorage::Attached::Model::ClassMethods)
+end


### PR DESCRIPTION
Rails 6.1 adds a service parameter to the methods, so there are separate methods for before and after 6.1.

Defined here: https://github.com/rails/rails/blob/9e08a5088b46fb3f8e2029498b4347d7eab2b3a5/activestorage/lib/active_storage/attached/model.rb

The `ActiveStorage::Attached::Model::ClassMethods` module needs to be mixed in for the methods in Rails models to be picked up by Sorbet.