### PR TITLE
add `add_belongs_to` support to activerecord migrations

### DIFF
--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -376,6 +376,8 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     polymorphic: false,
     null: nil
   ); end
+  
+  alias add_belongs_to add_reference
 
   sig do
     params(


### PR DESCRIPTION
simple one, but there are a lot of aliases that people use 🤷‍♂ 