### PR TITLE
Better ActiveModel/Record Type definitions

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -97,8 +97,28 @@ module ActiveModel::Validations
   end
 end
 
-class ActiveModel::Type::Boolean
+class ActiveModel::Type::Value
+  extend T::Sig
+
+  sig { params(precision: T.untyped, limit: T.untyped, scale: T.untyped).void }
+  def initialize(precision: nil, limit: nil, scale: nil); end
+
+  sig { params(value: T.untyped).returns(T.untyped) }
+  def cast(value); end
+end
+
+class ActiveModel::Type::Boolean < ActiveModel::Type::Value
   sig { params(arg0: T.untyped).returns(T.nilable(T::Boolean))}
+  def cast(arg0); end
+end
+
+class ActiveModel::Type::ImmutableString < ActiveModel::Type::Value
+  sig { params(arg0: T.untyped).returns(T.nilable(String))}
+  def cast(arg0); end
+end
+
+class ActiveModel::Type::String < ActiveModel::Type::ImmutableString
+  sig { params(arg0: T.untyped).returns(T.nilable(String))}
   def cast(arg0); end
 end
 

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -812,25 +812,9 @@ end
 
 class ActiveRecord::Result; end
 
-class ActiveRecord::Type::Value
-  extend T::Sig
-
-  sig { params(args: T.untyped).void }
-  def initialize(args); end
-
-  sig { params(value: T.untyped).returns(T.untyped) }
-  def cast(value); end
-end
-
-class ActiveRecord::Type::Boolean < ActiveRecord::Type::Value
-  extend T::Sig
-
-  sig { params(args: T.untyped).void }
-  def initialize(args = nil); end
-
-  sig { params(value: T.untyped).returns(T.nilable(T::Boolean)) }
-  def cast(value); end
-end
+ActiveRecord::Type::Value = ActiveModel::Type::Value
+ActiveRecord::Type::Boolean = ActiveModel::Type::Boolean
+ActiveRecord::Type::String = ActiveModel::Type::String
 
 module ActiveRecord
   class ActiveRecordError < StandardError; end
@@ -902,7 +886,7 @@ module ActiveRecord
   class TransactionIsolationError < ActiveRecordError; end
   class TransactionRollbackError < StatementInvalid; end
   class TypeConflictError < StandardError; end
-  class UnknownAttributeError < NoMethodError; end
+  UnknownAttributeError = ActiveModel::UnknownAttributeError
   class UnknownAttributeReference < ActiveRecordError; end
   class UnknownMigrationVersionError < MigrationError; end
   class UnknownPrimaryKey < ActiveRecordError; end


### PR DESCRIPTION
Rails defines all types inside `activemodel`: https://github.com/rails/rails/tree/v5.2.3/activemodel/lib/active_model/type

Then inside `activerecord` it just references them: https://github.com/rails/rails/blob/v5.2.3/activerecord/lib/active_record/type.rb#L56..L64

This change makes the type definitions match the Rails structure.

(The error change is the same, Rails does it [here](https://github.com/rails/rails/blob/v5.2.3/activerecord/lib/active_record/errors.rb#L252))

This is needed to make [tapioca](https://github.com/Shopify/tapioca) work with sorbet-typed, because it identifies the aliased constants, and the old sorbet-typed definitions were getting a "redefining constant" error. (`srb rbi gems` doesn't include these constants. So this change should be safe for non-tapioca users.)