### PR TITLE
Fix bad sig for ActiveRecord validation + issues with test script

### DIFF
--- a/.ci/run.rb
+++ b/.ci/run.rb
@@ -9,18 +9,30 @@ srb_flags = '--error-black-list 5002'
 
 gems = Dir.glob("lib/*").reject { |p| exclude.include?(p) }
 
+# some gems cross-reference constants from other gems. this is typical of Rails gems.
+# it's assumed that you'll never use just the one gem in isolation.
+# while this should be avoied, if absolutely necessary you can define dependencies here.
+# when running tests, all the values will also be required when testing the key.
+# (note that this is hard to identify when tests run because error 5002 (missing const) is ignored)
+deps = {
+  "lib/activerecord" => ["lib/activemodel", "lib/activesupport"]
+}
+
 results =
   gems.flat_map do |dir|
     versions = Dir.glob(dir + '/*').map { |f| File.basename(f) }
+
+    dirs = []
+    dirs << "#{dir}/all" if versions.include?('all')
+    dirs.concat(deps[dir]) if deps.key?(dir)
 
     # For each gem version, run the test and RBI files for that version and
     # for the "all" directory.
     versions.map do |version|
       puts "testing #{File.basename(dir)} #{version}"
-      dirs = ["#{dir}/#{version}"]
-      dirs << "#{dir}/all" if versions.include?('all')
-      dirs = dirs.uniq.map { |d| "\"#{d}\"" }.join(' ')
-      system("srb #{srb_cmd} #{srb_flags} #{dirs}")
+      dirs_for_version = dirs + ["#{dir}/#{version}"]
+      dirs_for_version = dirs_for_version.uniq.map { |d| "\"#{d}\"" }.join(' ')
+      system("srb #{srb_cmd} #{srb_flags} #{dirs_for_version}")
     end
   end
 

--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -16,8 +16,6 @@ module ActiveModel::Dirty
 end
 
 module ActiveModel::Validations
-  mixes_in_class_methods(ClassMethods)
-
   module ClassMethods
     # https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations.rb#L136-L154
     sig do
@@ -95,6 +93,8 @@ module ActiveModel::Validations
     )
     end
   end
+
+  mixes_in_class_methods(ClassMethods)
 end
 
 class ActiveModel::Type::Boolean
@@ -103,79 +103,6 @@ class ActiveModel::Type::Boolean
 end
 
 module ActiveModel::Validations::HelperMethods
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_absence_of(
-    *attr_names,
-    message: 'must be blank',
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
-
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      accept: T.untyped,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_acceptance_of(
-    *attr_names,
-    message: 'must be accepted',
-    accept: ['1', true],
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
-
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      case_sensitive: T::Boolean,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_confirmation_of(
-    *attr_names,
-    message: "doesn't match %{translated_attribute_name}",
-    case_sensitive: true,
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
-
   # A type alias for the in/within parameters on the
   # validates_(inclusion/exclusion)_of methods.
   InWithinType = T.type_alias do
@@ -190,231 +117,309 @@ module ActiveModel::Validations::HelperMethods
       )
     )
   end
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      in: InWithinType,
-      within: InWithinType,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_exclusion_of(
-    *attr_names,
-    message: 'is reserved',
-    in: nil,
-    within: nil,
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
 
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      with: T.untyped,
-      without: T.untyped,
-      multiline: T.untyped,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_format_of(
-    *attr_names,
-    message: 'is invalid',
-    with: nil,
-    without: nil,
-    multiline: nil,
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
+  module ClassMethods
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_absence_of(
+      *attr_names,
+      message: 'must be blank',
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
 
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      in: InWithinType,
-      within: InWithinType,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_inclusion_of(
-    *attr_names,
-    message: 'is not included in the list',
-    in: nil,
-    within: nil,
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        accept: T.untyped,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_acceptance_of(
+      *attr_names,
+      message: 'must be accepted',
+      accept: ['1', true],
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
 
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: T.nilable(String),
-      minimum: T.nilable(Integer),
-      maximum: T.nilable(Integer),
-      is: T.nilable(Integer),
-      within: T.nilable(T::Range[Integer]),
-      in: T.nilable(T::Range[Integer]),
-      too_long: String,
-      too_short: String,
-      wrong_length: String,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_length_of(
-    *attr_names,
-    message: nil,
-    minimum: nil,
-    maximum: nil,
-    is: nil,
-    within: nil,
-    in: nil,
-    too_long: 'is too long (maximum is %{count} characters)',
-    too_short: 'is too short (minimum is %{count} characters)',
-    wrong_length: 'is the wrong length (should be %{count} characters)',
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        case_sensitive: T::Boolean,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_confirmation_of(
+      *attr_names,
+      message: "doesn't match %{translated_attribute_name}",
+      case_sensitive: true,
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
 
-  # validates_size_of is an alias of validates_length_of
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: T.nilable(String),
-      minimum: T.nilable(Integer),
-      maximum: T.nilable(Integer),
-      is: T.nilable(Integer),
-      within: T.nilable(T::Range[Integer]),
-      in: T.nilable(T::Range[Integer]),
-      too_long: String,
-      too_short: String,
-      wrong_length: String,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_size_of(
-    *attr_names,
-    message: nil,
-    minimum: nil,
-    maximum: nil,
-    is: nil,
-    within: nil,
-    in: nil,
-    too_long: 'is too long (maximum is %{count} characters)',
-    too_short: 'is too short (minimum is %{count} characters)',
-    wrong_length: 'is the wrong length (should be %{count} characters)',
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        in: InWithinType,
+        within: InWithinType,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_exclusion_of(
+      *attr_names,
+      message: 'is reserved',
+      in: nil,
+      within: nil,
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
 
-  # Create a type alias so we don't have to repeat this long type signature 6 times.
-  NumberComparatorType = T.type_alias {T.nilable(T.any(Integer, Float, T.proc.params(arg0: T.untyped).returns(T::Boolean), Symbol))}
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      only_integer: T::Boolean,
-      greater_than: NumberComparatorType,
-      greater_than_or_equal_to: NumberComparatorType,
-      equal_to: NumberComparatorType,
-      less_than: NumberComparatorType,
-      less_than_or_equal_to: NumberComparatorType,
-      other_than: NumberComparatorType,
-      odd: T::Boolean,
-      even: T::Boolean,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
-  end
-  def validates_numericality_of(
-    *attr_names,
-    message: 'is not a number',
-    only_integer: false,
-    greater_than: nil,
-    greater_than_or_equal_to: nil,
-    equal_to: nil,
-    less_than: nil,
-    less_than_or_equal_to: nil,
-    other_than: nil,
-    odd: false,
-    even: false,
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        with: T.untyped,
+        without: T.untyped,
+        multiline: T.untyped,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_format_of(
+      *attr_names,
+      message: 'is invalid',
+      with: nil,
+      without: nil,
+      multiline: nil,
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
 
-  sig do
-    params(
-      attr_names: T.any(String, Symbol),
-      message: String,
-      if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
-      on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-      allow_nil: T::Boolean,
-      allow_blank: T::Boolean,
-      strict: T::Boolean
-    ).void
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        in: InWithinType,
+        within: InWithinType,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_inclusion_of(
+      *attr_names,
+      message: 'is not included in the list',
+      in: nil,
+      within: nil,
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
+
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: T.nilable(String),
+        minimum: T.nilable(Integer),
+        maximum: T.nilable(Integer),
+        is: T.nilable(Integer),
+        within: T.nilable(T::Range[Integer]),
+        in: T.nilable(T::Range[Integer]),
+        too_long: String,
+        too_short: String,
+        wrong_length: String,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_length_of(
+      *attr_names,
+      message: nil,
+      minimum: nil,
+      maximum: nil,
+      is: nil,
+      within: nil,
+      in: nil,
+      too_long: 'is too long (maximum is %{count} characters)',
+      too_short: 'is too short (minimum is %{count} characters)',
+      wrong_length: 'is the wrong length (should be %{count} characters)',
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
+
+    # validates_size_of is an alias of validates_length_of
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: T.nilable(String),
+        minimum: T.nilable(Integer),
+        maximum: T.nilable(Integer),
+        is: T.nilable(Integer),
+        within: T.nilable(T::Range[Integer]),
+        in: T.nilable(T::Range[Integer]),
+        too_long: String,
+        too_short: String,
+        wrong_length: String,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_size_of(
+      *attr_names,
+      message: nil,
+      minimum: nil,
+      maximum: nil,
+      is: nil,
+      within: nil,
+      in: nil,
+      too_long: 'is too long (maximum is %{count} characters)',
+      too_short: 'is too short (minimum is %{count} characters)',
+      wrong_length: 'is the wrong length (should be %{count} characters)',
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
+
+    # Create a type alias so we don't have to repeat this long type signature 6 times.
+    NumberComparatorType = T.type_alias {T.nilable(T.any(Integer, Float, T.proc.params(arg0: T.untyped).returns(T::Boolean), Symbol))}
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        only_integer: T::Boolean,
+        greater_than: NumberComparatorType,
+        greater_than_or_equal_to: NumberComparatorType,
+        equal_to: NumberComparatorType,
+        less_than: NumberComparatorType,
+        less_than_or_equal_to: NumberComparatorType,
+        other_than: NumberComparatorType,
+        odd: T::Boolean,
+        even: T::Boolean,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_numericality_of(
+      *attr_names,
+      message: 'is not a number',
+      only_integer: false,
+      greater_than: nil,
+      greater_than_or_equal_to: nil,
+      equal_to: nil,
+      less_than: nil,
+      less_than_or_equal_to: nil,
+      other_than: nil,
+      odd: false,
+      even: false,
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
+
+    sig do
+      params(
+        attr_names: T.any(String, Symbol),
+        message: String,
+        if: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        unless: T.any(Symbol, String, T.proc.params(arg0: T.untyped).returns(T::Boolean)),
+        on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
+        allow_nil: T::Boolean,
+        allow_blank: T::Boolean,
+        strict: T::Boolean
+      ).void
+    end
+    def validates_presence_of(
+      *attr_names,
+      message: "can't be blank",
+      if: nil,
+      unless: :_,
+      on: :_,
+      allow_nil: false,
+      allow_blank: false,
+      strict: false
+    ); end
   end
-  def validates_presence_of(
-    *attr_names,
-    message: "can't be blank",
-    if: nil,
-    unless: :_,
-    on: :_,
-    allow_nil: false,
-    allow_blank: false,
-    strict: false
-  ); end
+
+  mixes_in_class_methods(ClassMethods)
 end

--- a/lib/activemodel/all/activemodel_test.rb
+++ b/lib/activemodel/all/activemodel_test.rb
@@ -1,8 +1,8 @@
 # typed: true
 
 module ActiveModelTest
-  extend ActiveModel::Validations::HelperMethods
-  extend ActiveModel::Validations::ClassMethods
+  include ActiveModel::Validations
+  include ActiveModel::Validations::HelperMethods
 
   validates :bio, length: { maximum: 1000,
     too_long: "%{count} characters is the maximum allowed" }

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -271,6 +271,7 @@ class ActiveRecord::Base
   include ActiveModel::Conversion
   include ActiveRecord::Integration
   include ActiveModel::Validations
+  include ActiveModel::Validations::HelperMethods
   include ActiveRecord::CounterCache
   include ActiveRecord::Attributes
   include ActiveRecord::AttributeDecorators

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -927,8 +927,6 @@ end
 
 module ActiveRecord::Validations
   include ActiveModel::Validations
-
-  mixes_in_class_methods(ActiveModel::Validations::ClassMethods)
 end
 
 # Represents the schema of an SQL table in an abstract way. This class

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -270,7 +270,7 @@ class ActiveRecord::Base
   include ActiveRecord::AttributeAssignment
   include ActiveModel::Conversion
   include ActiveRecord::Integration
-  include ActiveRecord::Validations
+  include ActiveModel::Validations
   include ActiveRecord::CounterCache
   include ActiveRecord::Attributes
   include ActiveRecord::AttributeDecorators
@@ -923,10 +923,6 @@ end
 
 module ActiveRecord::Associations
   mixes_in_class_methods(ActiveRecord::Associations::ClassMethods)
-end
-
-module ActiveRecord::Validations
-  include ActiveModel::Validations
 end
 
 # Represents the schema of an SQL table in an abstract way. This class

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -80,6 +80,7 @@ end
 class ActiveRecordValidationTest < ApplicationRecord
   # this is defined in ActiveModel::Validations, but we test here to ensure that it's actually accessible from an AR model
   validate :run_validation_method, :if => :should_validate?, prepend: true
+  validates_absence_of :foo
 end
 
 class ActiveRecordMigrationsTest

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -77,6 +77,11 @@ class ActiveRecordCallbacksTest < ApplicationRecord
   end
 end
 
+class ActiveRecordValidationTest < ApplicationRecord
+  # this is defined in ActiveModel::Validations, but we test here to ensure that it's actually accessible from an AR model
+  validate :run_validation_method, :if => :should_validate?, prepend: true
+end
+
 class ActiveRecordMigrationsTest
   def test_table
     # Hack around the fact that change_table isn't included in the all/activerecord.rbi.


### PR DESCRIPTION
This change got a bit bigger than expected. This is the original test: https://github.com/sorbet/sorbet-typed/pull/216/commits/662fbad575fce4957dbbdf46d29b3a18e437615f - it was failing in this repo and I wasn't sure why.

It turns out, some gems (specifically `activerecord`) depend on lots of other gems in their rbis. When `sorbet-typed` runs its test script ([this](https://github.com/sorbet/sorbet-typed/blob/master/.ci/run.rb)), it tries to test each gem in isolation. It also ignores error 5002 (missing constant). The combined effect of these is that there's actually lots of errors we are ignoring. You can see this in action by running `srb tc "lib/activerecord/all"`

So this PR does a few things:

- Modifies to test script to use dependencies where required. I added a big warning about doing this as little as possible.
- Updates the `activemodel` tests to more closely resemble Rails sample code: https://api.rubyonrails.org/classes/ActiveModel/Validations.html. Specifically Rails suggests you `include`, not `extend`, so our test should do the same. I then updated the RBI to work with this usage.
- Gets my initial `activerecord` test passing, by fixing how `ActiveModel::Validations` is included in `ActiveRecord::Base`. (Note that this was still failing prior to the test script changes.)

I've tested these changes in our repo and they don't create any new errors. Have asked on slack for some other folks to test it too.

ps. the original motivation for this was I'm trying to adopt [tapioca](https://github.com/Shopify/tapioca) and the `mixes_in_class_methods` [here](https://github.com/sorbet/sorbet-typed/pull/216/files#diff-7e90d34d33bf5506c9cfaa31aed30980L931) was causing issues with the tapioca-generated rbi. That led me down a big rabbit hole.