### PR TITLE
Add blank?, empty?, and a few other methods to ActiveRecord::Relation

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1415,4 +1415,10 @@ end
 class ActiveRecord::Relation
   sig { returns(Integer) }
   def delete_all; end
+
+  sig { returns(T::Boolean) }
+  def blank?; end
+
+  sig { returns(T::Boolean) }
+  def empty?; end
 end

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1416,9 +1416,31 @@ class ActiveRecord::Relation
   sig { returns(Integer) }
   def delete_all; end
 
+  # Returns size of the records.
+  sig { returns(Integer) }
+  def size; end
+
+  # Returns true if relation is blank.
   sig { returns(T::Boolean) }
   def blank?; end
 
+  # Returns true if there are no records.
   sig { returns(T::Boolean) }
   def empty?; end
+
+  # Returns true if there are no records.
+  sig { returns(T::Boolean) }
+  def none?; end
+
+  # Returns true if there are any records.
+  sig { returns(T::Boolean) }
+  def any?; end
+
+  # Returns true if there is exactly one record.
+  sig { returns(T::Boolean) }
+  def one?; end
+
+  # Returns true if there is more than one record.
+  sig { returns(T::Boolean) }
+  def many?; end
 end

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -168,5 +168,10 @@ class ActiveRecordMigrationsTest
     relation = ActiveRecord::Relation.new
     T.assert_type!(relation.blank?, T::Boolean)
     T.assert_type!(relation.empty?, T::Boolean)
+    T.assert_type!(relation.any?, T::Boolean)
+    T.assert_type!(relation.many?, T::Boolean)
+    T.assert_type!(relation.one?, T::Boolean)
+    T.assert_type!(relation.none?, T::Boolean)
+    T.assert_type!(relation.size, Integer)
   end
 end

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -163,4 +163,10 @@ class ActiveRecordMigrationsTest
     ActiveRecordCallbacksTest.transaction(requires_new: true) do
     end
   end
+
+  def test_activerecord_instance_methods
+    relation = ActiveRecord::Relation.new
+    T.assert_type!(relation.blank?, T::Boolean)
+    T.assert_type!(relation.empty?, T::Boolean)
+  end
 end


### PR DESCRIPTION
Adds the following methods on `ActiveRecord::Relation`:

- [`empty?`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-empty-3F)
- [`blank?`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-blank-3F)
- [`any?`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-any-3F)
- [`none?`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-none-3F)
- [`many?`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-many-3F)
- [`one?`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-one-3F)
- [`size`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-size)