### PR TITLE
Fix optional arg in Grape

### DIFF
--- a/lib/grape/all/grape.rbi
+++ b/lib/grape/all/grape.rbi
@@ -208,10 +208,10 @@ class Grape::API
   sig do
     params(
       error_string: String,
-      status_code: Integer
+      status_code: T.nilable(Integer)
     ).void
   end
-  def self.error!(error_string, status_code)
+  def self.error!(error_string, status_code = nil)
   end
 
   sig do

--- a/lib/grape/all/grape.rbi
+++ b/lib/grape/all/grape.rbi
@@ -209,7 +209,7 @@ class Grape::API
     params(
       error_string: String,
       status_code: T.nilable(Integer)
-    ).void
+    ).returns(T.noreturn)
   end
   def self.error!(error_string, status_code = nil)
   end


### PR DESCRIPTION
https://github.com/ruby-grape/grape/blob/master/lib/grape/dsl/inside_route.rb#L145

- fixes an optional arg
- this method always throws, so `T.noreturn` is appropriate