### PR TITLE
Add .sorbet-typed.yml for specifying a major version.

### DIFF
--- a/.sorbet-typed.yml
+++ b/.sorbet-typed.yml
@@ -1,0 +1,3 @@
+# Used for communicating to Sorbet what version of sorbet-typed we're on, in
+# case we need to make breaking changes to the structure of this repo.
+version: 1


### PR DESCRIPTION
This allows us to make breaking changes and handle them in the sorbet gem. If we change this version to `2`, if the user is on an older version of Sorbet, it'll throw an error about the sorbet-typed repo being incompatible. That error can be resolved by upgrading to a newer version of Sorbet that does support the given major version.

The reason I want to add this is because I intend to fix [Sorbet's NTFS issue](https://github.com/sorbet/sorbet/issues/1782), and that'll require changing the names of all the directories in sorbet-typed, which in turn will require a change in Sorbet.

This will make it easier to communicate to users when we make that breaking change (and any in the future).