### PR TITLE
Add type definitions for sorbet-coerce

### DIFF
--- a/lib/sorbet-coerce/>=0.2.4/sorbet-coerce.rbi
+++ b/lib/sorbet-coerce/>=0.2.4/sorbet-coerce.rbi
@@ -1,0 +1,17 @@
+# typed: true
+module SafeType
+  class CoercionError < StandardError; end
+end
+
+module TypeCoerce
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig { params(args: T.untyped, raise_coercion_error: T.nilable(T::Boolean)).returns(Elem) }
+  def from(args, raise_coercion_error: nil); end
+
+  class CoercionError < SafeType::CoercionError; end
+  class ShapeError < SafeType::CoercionError; end
+end


### PR DESCRIPTION
This adds type definitions for [sorbet-coerce](https://github.com/chanzuckerberg/sorbet-coerce): A gem converts untyped data (e.g. user inputs) to typed objects.

Since adding the top-level RBI directory in the gem is causing https://github.com/sorbet/sorbet/issues/2732, we are removing it in the new release:
https://github.com/chanzuckerberg/sorbet-coerce/pull/39.

With the RBI file checked into sorbet-typed, we don't need to instruct people manually copy over it, which makes the installation process easier.