### PR TITLE
Add constraints and defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 ruby '2.5.7'
 
-gem 'sorbet', :group => :development
+gem 'rake', group: :development
+gem 'sorbet', group: :development

--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -707,8 +707,10 @@ module ActionDispatch::Routing::Mapper::Resources
     params(
       resources: T.any(String, Symbol),
       as: T.nilable(T.any(String, Symbol)),
+      constraints: T.untyped,
       controller: T.nilable(T.any(String, Symbol)),
       concerns: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      defaults: T.untyped,
       param: T.nilable(Symbol),
       path_names: T.untyped,
       path: T.untyped,
@@ -732,8 +734,10 @@ module ActionDispatch::Routing::Mapper::Resources
   def resources(
     *resources,
     as: nil,
+    constraints: nil,
     controller: nil,
     concerns: nil,
+    defaults: nil,
     param: nil,
     path_names: nil,
     path: nil,

--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -752,8 +752,8 @@ module ActionDispatch::Routing::Mapper::Resources
 
   # Technically, path doesn't have a default value set. However, this is
   # necessary to allow code like `root to: 'home#index'`.
-  sig { params(path: T.nilable(String), to: T.untyped).returns(T.untyped) }
-  def root(path = T.unsafe(nil), to: nil); end
+  sig { params(path: T.nilable(String), to: T.untyped, as: T.nilable(Symbol)).returns(T.untyped) }
+  def root(path = T.unsafe(nil), to: nil, as: nil); end
 
   sig { returns(T.untyped) }
   def shallow; end

--- a/lib/actionpack/all/actionpack_test.rb
+++ b/lib/actionpack/all/actionpack_test.rb
@@ -14,6 +14,7 @@ module ActionPackRoutesTest
   resources :cows, only: [:show, :index]
   resources :cows, except: :show
   resources :cows, except: [:show, :index]
+  resources :cows, defaults: { t: 21 }, constraints: { format: 'txt' }
 
   resources :games do
     get :search, on: :collection

--- a/lib/actionpack/all/actionpack_test.rb
+++ b/lib/actionpack/all/actionpack_test.rb
@@ -6,6 +6,7 @@ module ActionPackRoutesTest
 
   root 'home#index'
   root to: "home#index"
+  root to: 'alternative#index', as: :alternative_root
   get 'home/index'
 
   resources :posts, path_names: { new: "brand_new" }


### PR DESCRIPTION
Perhaps this deserves more than `T.untyped` but it at least allows my code to typecheck.

`root` is fairly undocumented (along with the rest of Rails) but we do use `as:` in our project. It seems likely it would take almost the same parameters as `get`, but I don't have time to check this right now.