### PR TITLE
Make constantize return a class

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -119,7 +119,7 @@ class String
   sig { returns(String) }
   def classify; end
 
-  sig { returns(Class) }
+  sig { returns(Module) }
   def constantize; end
 
   sig { returns(String) }

--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -119,7 +119,7 @@ class String
   sig { returns(String) }
   def classify; end
 
-  sig { returns(String) }
+  sig { returns(Class) }
   def constantize; end
 
   sig { returns(String) }


### PR DESCRIPTION
A Module is a Class so Class is the most correct return type

It raises if it isn't in existence, so not nilable