### PR TITLE
Add signature for ActiveSupport::TimeWithZone#midnight?

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -512,6 +512,9 @@ class ActiveSupport::TimeWithZone
   sig { returns(ActiveSupport::TimeWithZone) }
   def midnight; end
 
+  sig { returns(T::Boolean) }
+  def midnight?; end
+
   sig { returns(ActiveSupport::TimeWithZone) }
   def beginning_of_day; end
 


### PR DESCRIPTION
```ruby
Time.zone.now.class
# => ActiveSupport::TimeWithZone < Object
Time.zone.now.midnight?
#=> false
```