### PR TITLE
ActiveModel: presence accepts a hash

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -80,7 +80,7 @@ module ActiveModel::Validations
         length: T.any(T::Range[T.untyped], T::Hash[T.untyped, T.untyped]),
         numericality: T.any(T::Boolean, T::Hash[T.untyped, T.untyped]),
         on: T.any(Symbol, String, T::Array[T.any(Symbol, String)]),
-        presence: T::Boolean,
+        presence: T.any(T::Boolean, T::Hash[T.untyped, T.untyped]),
         size: T.any(T::Boolean, T::Hash[T.untyped, T.untyped]),
         strict: T::Boolean,
         uniqueness: T.any(T::Boolean, T::Hash[T.untyped, T.untyped]),

--- a/lib/activemodel/all/activemodel_test.rb
+++ b/lib/activemodel/all/activemodel_test.rb
@@ -38,6 +38,7 @@ module ActiveModelTest
   validates :age, numericality: true, on: [:create, :update]
 
   validates :token, presence: true, uniqueness: true, strict: TokenGenerationException
+  validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
 
   validates :card_number, presence: true, if: :paid_with_card?
 


### PR DESCRIPTION
Specific example here: https://github.com/rails/rails/blob/v5.2.3/activemodel/lib/active_model/validations/validates.rb#L104