### PR TITLE
`ActiveSupport.on_load` block bind fix

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -1,7 +1,7 @@
 # typed: strong
 
 module ActiveSupport
-  sig { params(kind: Symbol, blk: T.proc.bind(T.class_of(ActionController::Base)).void).void }
+  sig { params(kind: Symbol, blk: T.proc.bind(T.untyped).void).void }
   def self.on_load(kind, &blk); end
 end
 


### PR DESCRIPTION
As can be seen [here](https://github.com/rails/rails/blob/98a57aa5f610bc66af31af409c72173cdeeb3c9e/activesupport/lib/active_support/lazy_load_hooks.rb#L66), `ActiveSupport.on_load` can calls the block either using `instance_eval` or `class_eval` depending on the type of the `base` object that corresponds to the supplied `name` parameter. Thus, the best we can do is to bind it to `T.untyped`.