### PR TITLE
Update sidekiq.rbi sidekiq_retry_in to return nilable

### DIFF
--- a/lib/sidekiq/all/sidekiq.rbi
+++ b/lib/sidekiq/all/sidekiq.rbi
@@ -28,7 +28,7 @@ module Sidekiq::Worker::ClassMethods
   sig do
     params(
       blk: T.proc.params(count: Integer, exception: Exception).returns(Integer)
-    ).returns(Integer)
+    ).returns(T.nilable(Integer))
   end
   def sidekiq_retry_in(&blk); end
 


### PR DESCRIPTION
From the docs: " A return value of nil will use the default."

ref: https://github.com/mperham/sidekiq/wiki/Error-Handling