### PR TITLE
Sidekiq: allow sidekiq_options.queue to be set to String

### DIFF
--- a/lib/sidekiq/all/sidekiq.rbi
+++ b/lib/sidekiq/all/sidekiq.rbi
@@ -9,7 +9,7 @@ module Sidekiq::Worker::ClassMethods
 
   sig do
     params(
-      queue: T.nilable(Symbol),
+      queue: T.nilable(T.any(String, Symbol)),
       retry: T.nilable(T.any(Integer, T::Boolean)),
       backtrace: T.nilable(T.any(Integer, T::Boolean)),
       pool: T.nilable(Symbol),

--- a/lib/sidekiq/all/sidekiq_test.rb
+++ b/lib/sidekiq/all/sidekiq_test.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class Job
+  extend T::Sig
+  include Sidekiq::Worker
+
+  sidekiq_options(queue: 'default')
+end


### PR DESCRIPTION
That's how it is done in docs: 
https://www.rubydoc.info/gems/sidekiq/5.2.3/Sidekiq/Worker/ClassMethods#sidekiq_options-instance_method
https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues