### PR TITLE
ActiveSupport String#squish! returns String

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -193,7 +193,7 @@ class String
   sig { params(locale: Symbol).returns(String) }
   def singularize(locale = :en); end
 
-  sig { returns(T.untyped) }
+  sig { returns(String) }
   def squish!; end
 
   sig { returns(String) }


### PR DESCRIPTION
This changes the return type of `String#squish!` from ActiveSupport to `String` (was T.untyped).

Double checked activesupport/lib/active_support/core_ext/string/filters.rb, L18 -- `String#squish!` would always return a string.