### PR TITLE
allow inverse_of: to be false

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -33,7 +33,7 @@ module ActiveRecord::Associations::ClassMethods
       foreign_key: T.nilable(T.any(Symbol, String)),
       foreign_type: T.nilable(T.any(Symbol, String)),
       index_errors: T.nilable(T::Boolean),
-      inverse_of: T.nilable(T.any(Symbol, String)),
+      inverse_of: T.nilable(T.any(Symbol, String, FalseClass)),
       join_table: T.nilable(T.any(Symbol, String)),
       primary_key: T.nilable(T.any(Symbol, String)),
       source: T.nilable(T.any(Symbol, String)),


### PR DESCRIPTION
per https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html `inverse_of:` can be `false`:

```
You can turn off the automatic detection of inverse associations by setting the :inverse_of option to false like so:
```