### PR TITLE
Add a raise option to abstract_controller callbacks

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -771,10 +771,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def after_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def after_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   # append_after_action is an alias of after_action
   sig do
@@ -784,10 +785,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def append_after_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def append_after_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   # append_around_action is an alias of around_action
   sig do
@@ -797,10 +799,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def append_around_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def append_around_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   # append_before_action is an alias of before_action
   sig do
@@ -810,10 +813,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def append_before_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def append_before_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   sig do
     params(
@@ -822,10 +826,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def around_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def around_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   sig do
     params(
@@ -834,10 +839,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def before_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def before_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   sig do
     params(
@@ -846,10 +852,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def prepend_after_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def prepend_after_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   sig do
     params(
@@ -858,10 +865,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def prepend_around_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def prepend_around_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   sig do
     params(
@@ -870,10 +878,11 @@ module AbstractController::Callbacks::ClassMethods
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
       unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean,
       block: T.nilable(T.proc.returns(T.untyped))
     ).void
   end
-  def prepend_before_action(*names, except: nil, only: nil, if: nil, unless: nil, &block); end
+  def prepend_before_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true, &block); end
 
   sig do
     params(
@@ -881,10 +890,11 @@ module AbstractController::Callbacks::ClassMethods
       except: T.nilable(T.any(Symbol, T::Array[Symbol])),
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
-      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc))
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean
     ).void
   end
-  def skip_after_action(*names, except: nil, only: nil, if: nil, unless: nil); end
+  def skip_after_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true); end
 
   sig do
     params(
@@ -892,10 +902,11 @@ module AbstractController::Callbacks::ClassMethods
       except: T.nilable(T.any(Symbol, T::Array[Symbol])),
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
-      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc))
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean
     ).void
   end
-  def skip_around_action(*names, except: nil, only: nil, if: nil, unless: nil); end
+  def skip_around_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true); end
 
   sig do
     params(
@@ -903,10 +914,11 @@ module AbstractController::Callbacks::ClassMethods
       except: T.nilable(T.any(Symbol, T::Array[Symbol])),
       only: T.nilable(T.any(Symbol, T::Array[Symbol])),
       if: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
-      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc))
+      unless: T.nilable(T.any(Symbol, T::Array[Symbol], Proc)),
+      raise: T::Boolean
     ).void
   end
-  def skip_before_action(*names, except: nil, only: nil, if: nil, unless: nil); end
+  def skip_before_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true); end
 end
 
 # https://api.rubyonrails.org/classes/ActionController/MimeResponds.html


### PR DESCRIPTION
### Motivation
Currently, the abstract_controller callbacks do not take a raise option, but in reality, they can:
https://github.com/rails/rails/blob/40b7d93c5bf04974cfd0201a8e391c499c046f0b/activesupport/lib/active_support/callbacks.rb#L700

This option is used by `skip_callback` provided by active support. Hence, this adds the raise options to all abstract_controller callback definitions.

### Test Plan
Use the patched file in the project I'm working on. `srb tc` and see no related errors.