### PR TITLE
Allow #params call from within Grape::API.helpers

### DIFF
--- a/lib/grape/all/grape.rbi
+++ b/lib/grape/all/grape.rbi
@@ -72,6 +72,14 @@ class Grape::API
 
   sig do
     params(
+      block: T.nilable(T.proc.void)
+    ).returns(T::Hash[T.untyped, T.untyped])
+  end
+  def params(&block)
+  end
+
+  sig do
+    params(
       route: String,
       block: T.nilable(T.proc.void)
     ).void

--- a/lib/grape/all/grape_test.rb
+++ b/lib/grape/all/grape_test.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+class GrapeTest < Grape::API
+  extend T::Sig
+
+  params do
+    requires :nothing
+  end
+  get '' do
+  end
+
+  helpers do
+    sig { void }
+    def verify_params_as_instance_variable
+      params
+
+      params do
+        #something
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a Grape [`helpers` block](https://github.com/ruby-grape/grape#helpers) is used, the `params` method is an instance method instead of a class method. This PR makes the class method signature available as an instance method.