### PR TITLE
`inheritance_column` can be set to nil

### DIFF
--- a/lib/activerecord/all/model_schema.rbi
+++ b/lib/activerecord/all/model_schema.rbi
@@ -26,7 +26,7 @@ module ActiveRecord::ModelSchema::ClassMethods
   def inheritance_column
   end
 
-  sig { params(value: String).void }
+  sig { params(value: T.nilable(String)).void }
   def inheritance_column=(value)
   end
 


### PR DESCRIPTION
You would want to do this if you have a column called `type` on your model, but it *isn't* used for single table inheritance.

Slight tweak to https://github.com/sorbet/sorbet-typed/pull/237, cc @dikond 

Example from our codebase:

![image](https://user-images.githubusercontent.com/509837/81001198-005c7600-8e0d-11ea-9e45-9ee3b340d83f.png)
![image](https://user-images.githubusercontent.com/509837/81001231-0bafa180-8e0d-11ea-895b-82dc8e3eab26.png)
