### PR TITLE
Add shellwords.rbi

### DIFF
--- a/lib/ruby/all/shellwords.rbi
+++ b/lib/ruby/all/shellwords.rbi
@@ -1,0 +1,24 @@
+# typed: strict
+
+module Shellwords
+  sig { params(str: String).returns(String) }
+  def self.escape(str); end
+
+  sig { params(str: T::Array[String]).returns(String) }
+  def self.join(str); end
+
+  sig { params(str: String).returns(String) }
+  def self.shellescape(str); end
+
+  sig { params(str: T::Array[String]).returns(String) }
+  def self.shelljoin(str); end
+
+  sig { params(str: String).returns(T::Array[String]) }
+  def self.shellsplit(str); end
+
+  sig { params(str: String).returns(T::Array[String]) }
+  def self.shellwords(str); end
+
+  sig { params(str: String).returns(T::Array[String]) }
+  def self.split(str); end
+end


### PR DESCRIPTION
Part of the stdlib. Used the documentation as a guide.

https://ruby-doc.org/stdlib-2.5.1/libdoc/shellwords/rdoc/Shellwords.html#method-c-escape