### PR TITLE
Remove all reference of Virtus

### DIFF
--- a/lib/grape/all/grape.rbi
+++ b/lib/grape/all/grape.rbi
@@ -1,11 +1,6 @@
 # typed: strong
 
-class Virtus::Attribute::Boolean
-end
-
 class Grape::API
-  Boolean = Virtus::Attribute::Boolean
-
   sig do
     params(
       name: Symbol,


### PR DESCRIPTION
It was removed in Grape 1.3: https://github.com/ruby-grape/grape/pull/1920 / https://github.com/ruby-grape/grape/blob/master/UPGRADING.md#upgrading-to--130

I'm not sure this particular constant definition is useful anyway.