### PR TITLE
Add ActiveRecord::Transactions::ClassMethods after_create_commit definition

### DIFF
--- a/lib/activerecord/~>5/activerecord.rbi
+++ b/lib/activerecord/~>5/activerecord.rbi
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 
 class ActiveRecord::Base
 

--- a/lib/activerecord/~>5/activerecord.rbi
+++ b/lib/activerecord/~>5/activerecord.rbi
@@ -1,0 +1,17 @@
+# typed: strong
+
+class ActiveRecord::Base
+
+  sig do
+  params(
+    arg: T.any(Symbol, T.proc.returns(T.untyped)),
+    if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+    unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
+  ).void
+  end
+  def self.after_create_commit(
+    arg,
+    if: nil,
+    unless: nil
+  ); end
+end

--- a/lib/activerecord/~>5/activerecord_test.rb
+++ b/lib/activerecord/~>5/activerecord_test.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class ActiveRecordCallbacksTest < ApplicationRecord
+
+  after_create_commit :log_create_commit_action
+  after_create_commit :log_user_saved_to_db, if: :author_wants_emails?, unless: Proc.new { |comment| comment.article.ignore_comments? }
+end


### PR DESCRIPTION
Adding [after_create_commit](https://apidock.com/rails/v5.0.0.1/ActiveRecord/Transactions/ClassMethods/after_create_commit) definition for Rails 5+