### PR TITLE
Add to_date method to ActiveSupport::TimeWithZone.

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -874,6 +874,9 @@ class ActiveSupport::TimeWithZone
   sig { returns(Rational) }
   def to_r; end
 
+  sig { returns(Date) }
+  def to_date; end
+
   # Returns an instance of DateTime with the timezone's UTC offset
   #
   # ```ruby

--- a/lib/activesupport/all/activesupport_times_test.rb
+++ b/lib/activesupport/all/activesupport_times_test.rb
@@ -23,6 +23,7 @@ module ActiveSupportTimesTest
   Time.zone.now.to_r
   Time.zone.now.to_i
   Time.zone.now.to_f
+  Time.zone.now.to_date
   Time.zone.now.to_datetime
   Time.zone.now.to_time
   Time.zone.today


### PR DESCRIPTION
The method is generated here: https://github.com/rails/rails/blob/ab06682534f63257f33ad81e4c87931e36658cb7/activesupport/lib/active_support/time_with_zone.rb#L426

I noticed this was missing when doing some stuff with dates in my app :)