### PR TITLE
add Sidekiq::CLI to sidekiq.rbi

### DIFF
--- a/lib/sidekiq/all/sidekiq.rbi
+++ b/lib/sidekiq/all/sidekiq.rbi
@@ -39,3 +39,18 @@ module Sidekiq::Worker::ClassMethods
   end
   def sidekiq_retries_exhausted(&blk); end
 end
+
+module Sidekiq
+  class CLI
+    sig { returns(Sidekiq::CLI) }
+    def self.instance; end
+
+    sig { returns(Sidekiq::Launcher) }
+    def launcher; end
+  end
+
+  class Launcher
+    sig { returns(T::Boolean) }
+    def stopping?; end
+  end
+end


### PR DESCRIPTION
Sidekiq::CLI gives workers the option to determine if sidekiq is trying to quit, and then put themselves in a good place to be restarted when sidekiq restarts.