### PR TITLE
ActiveRecord::CollectionCacheKey is removed in Rails 6

### DIFF
--- a/lib/activerecord/<6/activerecord.rbi
+++ b/lib/activerecord/<6/activerecord.rbi
@@ -1,0 +1,6 @@
+# typed: strong
+
+class ActiveRecord::Base
+  # removed in rails 6: https://github.com/rails/rails/pull/35848
+  extend ActiveRecord::CollectionCacheKey
+end

--- a/lib/activerecord/>=5.2/activerecord.rbi
+++ b/lib/activerecord/>=5.2/activerecord.rbi
@@ -2,7 +2,6 @@
 
 class ActiveRecord::Base
   extend ActiveRecord::Delegation::DelegateCache
-  extend ActiveRecord::CollectionCacheKey
   include ActiveRecord::DefineCallbacks
   include ActiveRecord::TouchLater
   include ActiveRecord::SecureToken


### PR DESCRIPTION
See https://github.com/rails/rails/pull/35848