### PR TITLE
Add AR#blank? and AR#present?

### DIFF
--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -466,3 +466,11 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
   sig { params(sql: String, name: T.nilable(String)).returns(T.untyped) }
   def execute(sql, name = nil); end
 end
+
+module ActiveRecord::Core
+  sig { returns(T::Boolean) }
+  def blank?; end
+
+  sig { returns(T::Boolean) }
+  def present?; end
+end

--- a/lib/activerecord/~>6.0.0/activerecord_test.rb
+++ b/lib/activerecord/~>6.0.0/activerecord_test.rb
@@ -122,3 +122,9 @@ class ActiveRecordOldMigrationsTest < ActiveRecord::Migration::Compatibility::V5
     end
   end
 end
+
+class ActiveRecordCoreTest < ApplicationRecord
+end
+obj = ActiveRecordCoreTest.new
+T.assert_type!(obj.present?, T::Boolean)
+T.assert_type!(obj.blank?, T::Boolean)


### PR DESCRIPTION
Added to rails 6 here: https://github.com/rails/rails/commit/cc2d614e6310337a9d34ede3e67d634d84561cde

I considered making these return `TrueClass` and `FalseClass`, but that resulted in a _lot_ of new sorbet errors in our project (mostly "this code is unreachable" where we are doing `ar_object.present?`). I'm open to changing that, but I think the way I've done it here will cause much less pain for sorbet-typed users.