### PR TITLE
GraphQL: tells sorbet that field_class exists in Interface

### DIFF
--- a/lib/graphql/all/graphql.rbi
+++ b/lib/graphql/all/graphql.rbi
@@ -16,10 +16,8 @@ class GraphQL::Schema::Object < GraphQL::Schema::Member
   extend GraphQL::Schema::Member::HasArguments
 end
 
-module Types::BaseInterface
-   # srb rbi gems does *not* add the next line, which means arguments don't work out of the box
-  # Note this isn't strictly correct. see https://github.com/sorbet/sorbet-typed/pull/166
-  extend GraphQL::Schema::Member::HasFields
+module GraphQL::Schema::Interface
+  mixes_in_class_methods(::GraphQL::Schema::Member::HasFields)
 end
 
 class GraphQL::Schema::Enum < GraphQL::Schema::Member

--- a/lib/graphql/all/graphql.rbi
+++ b/lib/graphql/all/graphql.rbi
@@ -16,6 +16,12 @@ class GraphQL::Schema::Object < GraphQL::Schema::Member
   extend GraphQL::Schema::Member::HasArguments
 end
 
+module Types::BaseInterface
+   # srb rbi gems does *not* add the next line, which means arguments don't work out of the box
+  # Note this isn't strictly correct. see https://github.com/sorbet/sorbet-typed/pull/166
+  extend GraphQL::Schema::Member::HasFields
+end
+
 class GraphQL::Schema::Enum < GraphQL::Schema::Member
   # Define a value for this enum
   #

--- a/lib/graphql/all/graphql.rbi
+++ b/lib/graphql/all/graphql.rbi
@@ -16,6 +16,10 @@ class GraphQL::Schema::Object < GraphQL::Schema::Member
   extend GraphQL::Schema::Member::HasArguments
 end
 
+module GraphQL::Schema::Member::HasFields
+  def field_class(new_field_class = nil); end
+end
+
 module GraphQL::Schema::Interface
   mixes_in_class_methods(::GraphQL::Schema::Member::HasFields)
 end

--- a/lib/graphql/all/graphql_test.rb
+++ b/lib/graphql/all/graphql_test.rb
@@ -9,6 +9,11 @@ module GraphqlTest
       argument :id, ID, "The ID of the user to find", required: true
     end
   end
+  
+  module BaseInterface
+    include GraphQL::Schema::Interface
+    field_class Types::BaseField
+  end
 
   class CardinalDirectionType < GraphQL::Schema::Enum
     value "NORTH", value: 'north'


### PR DESCRIPTION
The BaseInterface generated by graphql is like this
```
# typed: true
module Types
  module BaseInterface
    include GraphQL::Schema::Interface

    field_class Types::BaseField
  end
end
```
Sorbet doesn't know that the "field_class" method exists. We can tell it that by using "mixes_in_class_methods" in the Schema::Interface module