### PR TITLE
Update aasm.rbi

### DIFF
--- a/lib/aasm/all/aasm.rbi
+++ b/lib/aasm/all/aasm.rbi
@@ -37,13 +37,15 @@ module AASM::ClassMethods
     params(
       from: T.any(T.nilable(Symbol), T::Array[Symbol]),
       to: T.nilable(Symbol),
-      guard: T.nilable(Symbol)
+      guard: T.nilable(Symbol),
+      after: T.nilable(Symbol)
     ).void
   end
   def transitions(
     from: nil,
     to: nil,
-    guard: nil
+    guard: nil,
+    after: nil
   )
   end
 


### PR DESCRIPTION
Adds the `after` argument for transitions.

The method itself is defined [here.](https://github.com/aasm/aasm/blob/d65df64db6ddd89dec4b186c78a6da501c0d8979/lib/aasm/core/event.rb#L94)
`after` is used [here.](https://github.com/aasm/aasm/blob/d65df64db6ddd89dec4b186c78a6da501c0d8979/lib/aasm/core/transition.rb#L24)
