### PR TITLE
add has_secure_token to ActiveRecord::Base

### DIFF
--- a/lib/activerecord/>=5/activerecord.rbi
+++ b/lib/activerecord/>=5/activerecord.rbi
@@ -40,4 +40,7 @@ class ActiveRecord::Base
     if: nil,
     unless: nil
   ); end
+
+  sig { params(attribute: T.any(Symbol, String)).void }
+  def self.has_secure_token(attribute); end
 end

--- a/lib/activerecord/>=5/activerecord_test.rb
+++ b/lib/activerecord/>=5/activerecord_test.rb
@@ -10,4 +10,6 @@ class ActiveRecordCallbacksTest < ApplicationRecord
 
   after_destroy_commit :log_destroy_commit_action
   after_destroy_commit :log_user_deleted_from_db, if: :author_wants_emails?, unless: Proc.new { |comment| comment.article.ignore_comments? }
+
+  has_secure_token :secure_token
 end


### PR DESCRIPTION
This PR adds the sig for `ActiveRecord::Base#has_secure_token`.

This method has been added to Rails on v5.0.0 as per this PR: rails/rails#18217