### PR TITLE
Fix ActiveSupport::TimeZone#[] method return type to be nilable

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -1019,7 +1019,7 @@ class ActiveSupport::TimeZone
   # numeric value it is either the hour offset, or the second offset, of the
   # timezone to find. (The first one with that offset will be returned.)
   # Returns `nil` if no such time zone is known to the system.
-  sig { params(arg: T.any(String, Numeric, ActiveSupport::Duration)).returns(ActiveSupport::TimeZone) }
+  sig { params(arg: T.any(String, Numeric, ActiveSupport::Duration)).returns(T.nilable(ActiveSupport::TimeZone)) }
   def self.[](arg); end
 
   # Returns an array of all TimeZone objects. There are multiple


### PR DESCRIPTION
`self.[]` on `ActiveSupport::TimeZone` returns `nil` if no such time zone is known to the system.

![image](https://user-images.githubusercontent.com/13454550/87831824-70ab5d00-c87c-11ea-8ed1-d1df2662d114.png)
Docs: https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html#method-c-5B-5D