### PR TITLE
Fix up types for `ActiveSupport::Duration#from_now` and `ActiveSupport::Duration#ago`

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -1409,11 +1409,11 @@ class ActiveSupport::Duration
   sig { params(precision: T.nilable(Integer)).returns(String) }
   def iso8601(precision: nil); end
 
-  sig { returns(ActiveSupport::TimeWithZone) }
-  def from_now; end
+  sig { params(time: ActiveSupport::TimeWithZone).returns(ActiveSupport::TimeWithZone) }
+  def from_now(time = Time.current); end
 
-  sig { returns(ActiveSupport::TimeWithZone) }
-  def ago; end
+  sig { params(time: ActiveSupport::TimeWithZone).returns(ActiveSupport::TimeWithZone) }
+  def ago(time = Time.current); end
 end
 
 module Benchmark


### PR DESCRIPTION
`ActiveSupport::Duration#from_now` and `ActiveSupport::Duration#ago` accept an optional argument `time` which can be an `ActiveSupport::TimeWithZone` or `Date`

`from_now` docs: https://api.rubyonrails.org/classes/ActiveSupport/Duration.html#method-i-from_now
`ago` docs: https://api.rubyonrails.org/classes/ActiveSupport/Duration.html#method-i-ago

Examples:
![image](https://user-images.githubusercontent.com/13454550/88208105-9fdd1800-cc48-11ea-8362-e7d8083a793e.png)