### PR TITLE
activerecord: counter_cache on belongs_to

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -119,7 +119,7 @@ module ActiveRecord::Associations::ClassMethods
       scope: T.nilable(T.proc.void),
       autosave: T.nilable(T::Boolean),
       class_name: T.nilable(T.any(Symbol, String)),
-      counter_cache: T.nilable(T::Boolean),
+      counter_cache: T.nilable(T.any(Symbol, String, T::Boolean)),
       dependent: T.nilable(T.any(Symbol, String)),
       foreign_key: T.nilable(T.any(Symbol, String)),
       foreign_type: T.nilable(T.any(Symbol, String)),


### PR DESCRIPTION
The type for counter_cache on belongs_to can be any of Symbol, String or Boolean - See: https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-counter-cache