### PR TITLE
Fix return type of in_time_zone

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -593,7 +593,7 @@ class ActiveSupport::TimeWithZone
   def period; end
 
   # Returns the simultaneous time in `Time.zone`, or the specified zone.
-  sig { params(new_zone: T.untyped).returns(Time) }
+  sig { params(new_zone: T.untyped).returns(ActiveSupport::TimeWithZone) }
   def in_time_zone(new_zone = ::Time.zone); end
 
   # Returns a `Time` instance of the simultaneous time in the system timezone.


### PR DESCRIPTION
```
[17] pry(main)> 3.hours.ago
=> Sat, 25 Jul 2020 22:21:19 AEST +10:00
[18] pry(main)> 3.hours.ago.class
=> ActiveSupport::TimeWithZone
[19] pry(main)> 3.hours.ago.in_time_zone("UTC").class
=> ActiveSupport::TimeWithZone
```