### PR TITLE
Update sig for `sidekiq_retry_in`

### DIFF
--- a/lib/sidekiq/all/sidekiq.rbi
+++ b/lib/sidekiq/all/sidekiq.rbi
@@ -27,8 +27,8 @@ module Sidekiq::Worker::ClassMethods
   
   sig do
     params(
-      blk: T.proc.params(count: Integer, exception: Exception).returns(Integer)
-    ).returns(T.nilable(Integer))
+      blk: T.proc.params(count: Integer, exception: Exception).returns(T.nilable(Integer))
+    ).void
   end
   def sidekiq_retry_in(&blk); end
 


### PR DESCRIPTION
The return value of the block is a nilable Integer, not the return value of the method itself, which is more properly typed as `void`

From the docs: " A return value of nil will use the default." ref: https://github.com/mperham/sidekiq/wiki/Error-Handling
Target code being typed: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/worker.rb#L56