### PR TITLE
Update activerecord.rbi

### DIFF
--- a/lib/activerecord/~>5.2.0/activerecord.rbi
+++ b/lib/activerecord/~>5.2.0/activerecord.rbi
@@ -334,7 +334,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
   sig do
     params(
       table_name: T.any(String, Symbol),
-      column_name: T.any(String, Symbol),
+      column_name: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
       options: T.untyped
     ).returns(T::Boolean)
   end
@@ -378,7 +378,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     polymorphic: false,
     null: nil
   ); end
-  
+
   alias add_belongs_to add_reference
 
   sig do

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -364,7 +364,7 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
   sig do
     params(
       table_name: T.any(String, Symbol),
-      column_name: T.any(String, Symbol),
+      column_name: T.any(String, Symbol, T::Array[T.any(String, Symbol)]),
       options: T.untyped
     ).returns(T::Boolean)
   end


### PR DESCRIPTION

As [documented in ApiDock](https://apidock.com/rails/v6.0.0/ActiveRecord/ConnectionAdapters/SchemaStatements/index_exists%3F), the method `index_exists?` from `ActiveRecord::ConnectionAdapters::SchemaStatements` can be called with either a single column, or multiple columns in an array:
```ruby
# Check an index exists
index_exists?(:suppliers, :company_id)

# Check an index on multiple columns exists
index_exists?(:suppliers, [:company_id, :company_type])
```