### PR TITLE
Add a missing param to index_with.

### DIFF
--- a/lib/activesupport/>=6/activesupport.rbi
+++ b/lib/activesupport/>=6/activesupport.rbi
@@ -20,10 +20,11 @@ module Enumerable
   # the case where a block isn't given isn't handled - that seems like an unlikely case
   sig do
     type_parameters(:key).params(
+      default: T.untyped,
       block: T.proc.params(o: Enumerable::Elem).returns(T.type_parameter(:key))
     ).returns(
       T::Hash[Enumerable::Elem, T.type_parameter(:key)]
     )
   end
-  def index_with(&block); end
+  def index_with(default = T.unsafe(nil), &block); end
 end


### PR DESCRIPTION
The `index_with` method has a `default` parameter that wasn't added in #280. https://api.rubyonrails.org/classes/Enumerable.html#method-i-index_with

This caused sorbet to mark the file false. As far as I can tell, this should only cause a change in that the file will be marked as strict instead now that it matches the method signature that sorbet finds automatically.

If the user actually passes the `default` parameter to the method, the type returned will be incorrect, but that's not really fixable and I agree with the original logic that it wasn't a likely-enough case that it mattered.

cc: @ghiculescu 