### PR TITLE
Type parse-cron

### DIFF
--- a/lib/parse-cron/all/parse-cron.rbi
+++ b/lib/parse-cron/all/parse-cron.rbi
@@ -15,12 +15,12 @@ class CronParser
   def interpret_vixieisms(spec); end
 
   # returns the next occurence after the given date
-  sig { params(now: Time, num: Integer).returns(T.any(Time, T::Array[Time]))  }
-  def next(now = @time_source.now, num = 1); end
+  sig { params(now: Time).returns(Time)  }
+  def next(now = @time_source.now); end
 
   # returns the last occurence before the given date
-  sig { params(now: Time, num: Integer).returns(T.any(Time, T::Array[Time]))  }
-  def last(now = @time_source.now, num=1); end
+  sig { params(now: Time).returns(Time)  }
+  def last(now = @time_source.now); end
 
   SUBELEMENT_REGEX = T.let(%r{}, Regexp)
 

--- a/lib/parse-cron/all/parse-cron.rbi
+++ b/lib/parse-cron/all/parse-cron.rbi
@@ -1,0 +1,134 @@
+# typed: strict
+
+# Parses cron expressions and computes the next occurence of the "job"
+#
+class CronParser
+  extend T::Sig
+  extend T::Generic
+
+  # NOTE: Make these variant if you use the alternate sigs for later methods.
+  SourceClass = type_member(fixed: T.class_of(Time))
+  Source = type_member(fixed: Time)
+
+  SYMBOLS = T.let({}, T::Hash[String, String])
+
+  sig { params(source: String).void }
+  def initialize(source); end
+
+  # # NOTE: This is the more complete signature of initialize:
+  # sig { params(source: String, time_source: SourceClass).void }
+  # def initialize(source, time_source = Time); end
+
+  sig { params(spec: String).returns(String) }
+  def interpret_vixieisms(spec); end
+
+  # returns the next occurence after the given date
+  sig { params(now: Source).returns(Source) }
+  def next(now = @time_source.now); end
+
+  # # NOTE: This is the more complete signature of next:
+  # sig { params(now: Source, num: Integer).returns(T.any(Source, T::Array[Source])) }
+  # def next(now = @time_source.now, num = 1); end
+
+  # returns the last occurence before the given date
+  sig { params(now: Source).returns(Source) }
+  def last(now = @time_source.now); end
+
+  # # NOTE: This is the more complete signature of last:
+  # sig { params(now: Source, num: Integer).returns(T.any(Source, T::Array[Source])) }
+  # def last(now = @time_source.now, num = 1); end
+
+  SUBELEMENT_REGEX = T.let(%r{}, Regexp)
+
+  sig do
+    params(
+      elem: String,
+      allowed_range: T::Range[Integer],
+    ).returns([T::Set[Integer], T::Array[Integer], String])
+  end
+  def parse_element(elem, allowed_range); end
+
+  protected
+
+  sig { params(meth: Symbol, time: Source, num: Integer).returns(T::Array[Source])  }
+  def recursive_calculate(meth,time,num); end
+
+  # returns a list of days which do both match time_spec[:dom] or time_spec[:dow]
+  sig { params(year: Integer, month: Integer).returns([T::Set[Integer], T::Array[Integer]])  }
+  def interpolate_weekdays(year, month); end
+
+  sig { params(year: Integer, month: Integer).returns([T::Set[Integer], T::Array[Integer]])  }
+  def interpolate_weekdays_without_cache(year, month); end
+
+  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(Integer)  }
+  def nudge_year(t, dir = :next); end
+
+  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(Integer)  }
+  def nudge_month(t, dir = :next); end
+
+  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(T::Boolean)  }
+  def date_valid?(t, dir = :next); end
+
+  sig do
+    params(
+      t: InternalTime[SourceClass, Source],
+      dir: Symbol,
+      can_nudge_month: T::Boolean,
+    ).returns(T.nilable(Integer))
+  end
+  def nudge_date(t, dir = :next, can_nudge_month = true); end
+
+  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(T.nilable(Integer))  }
+  def nudge_hour(t, dir = :next); end
+
+  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(T.nilable(Integer))  }
+  def nudge_minute(t, dir = :next); end
+
+  sig { returns(T::Hash[Symbol, [T::Set[Integer], T::Array[Integer], String]]) }
+  def time_specs; end
+
+  sig { params(str: String).returns(String)  }
+  def substitute_parse_symbols(str); end
+
+  sig { params(rng: T::Range[Integer], step: Integer).returns(T::Array[Integer])  }
+  def stepped_range(rng, step = 1); end
+
+  # returns the smallest element from allowed which is greater than current
+  # returns nil if no matching value was found
+  sig do
+    params(
+      current: Integer,
+      allowed: T::Array[Integer],
+      dir: Symbol,
+    ).returns(T.nilable(Integer))
+  end
+  def find_best_next(current, allowed, dir); end
+
+  sig { void }
+  def validate_source; end
+end
+
+# internal "mutable" time representation
+class CronParser::InternalTime
+  extend T::Sig
+  extend T::Generic
+
+  SourceClass = type_member
+  Source = type_member
+
+  sig { returns(Integer) }
+  attr_accessor :year, :month, :day, :hour, :min
+
+  sig { returns(SourceClass) }
+  attr_accessor :time_source
+
+  sig { params(time: Source, time_source: SourceClass).void }
+  def initialize(time, time_source = Time); end
+
+  sig { returns(Source) }
+  def to_time; end
+
+  sig { returns(String) }
+  def inspect; end
+end
+

--- a/lib/parse-cron/all/parse-cron.rbi
+++ b/lib/parse-cron/all/parse-cron.rbi
@@ -6,37 +6,21 @@ class CronParser
   extend T::Sig
   extend T::Generic
 
-  # NOTE: Make these variant if you use the alternate sigs for later methods.
-  SourceClass = type_member(fixed: T.class_of(Time))
-  Source = type_member(fixed: Time)
-
   SYMBOLS = T.let({}, T::Hash[String, String])
 
-  sig { params(source: String).void }
-  def initialize(source); end
-
-  # # NOTE: This is the more complete signature of initialize:
-  # sig { params(source: String, time_source: SourceClass).void }
-  # def initialize(source, time_source = Time); end
+  sig { params(source: String, time_source: T.class_of(Time)).void }
+  def initialize(source, time_source = Time); end
 
   sig { params(spec: String).returns(String) }
   def interpret_vixieisms(spec); end
 
   # returns the next occurence after the given date
-  sig { params(now: Source).returns(Source) }
-  def next(now = @time_source.now); end
-
-  # # NOTE: This is the more complete signature of next:
-  # sig { params(now: Source, num: Integer).returns(T.any(Source, T::Array[Source])) }
-  # def next(now = @time_source.now, num = 1); end
+  sig { params(now: Time, num: Integer).returns(T.any(Time, T::Array[Time]))  }
+  def next(now = @time_source.now, num = 1); end
 
   # returns the last occurence before the given date
-  sig { params(now: Source).returns(Source) }
-  def last(now = @time_source.now); end
-
-  # # NOTE: This is the more complete signature of last:
-  # sig { params(now: Source, num: Integer).returns(T.any(Source, T::Array[Source])) }
-  # def last(now = @time_source.now, num = 1); end
+  sig { params(now: Time, num: Integer).returns(T.any(Time, T::Array[Time]))  }
+  def last(now = @time_source.now, num=1); end
 
   SUBELEMENT_REGEX = T.let(%r{}, Regexp)
 
@@ -50,7 +34,7 @@ class CronParser
 
   protected
 
-  sig { params(meth: Symbol, time: Source, num: Integer).returns(T::Array[Source])  }
+  sig { params(meth: Symbol, time: Time, num: Integer).returns(T::Array[Time])  }
   def recursive_calculate(meth,time,num); end
 
   # returns a list of days which do both match time_spec[:dom] or time_spec[:dow]
@@ -60,28 +44,28 @@ class CronParser
   sig { params(year: Integer, month: Integer).returns([T::Set[Integer], T::Array[Integer]])  }
   def interpolate_weekdays_without_cache(year, month); end
 
-  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(Integer)  }
+  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(Integer)  }
   def nudge_year(t, dir = :next); end
 
-  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(Integer)  }
+  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(Integer)  }
   def nudge_month(t, dir = :next); end
 
-  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(T::Boolean)  }
+  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(T::Boolean)  }
   def date_valid?(t, dir = :next); end
 
   sig do
     params(
-      t: InternalTime[SourceClass, Source],
+      t: InternalTime[T.class_of(Time), Time],
       dir: Symbol,
       can_nudge_month: T::Boolean,
     ).returns(T.nilable(Integer))
   end
   def nudge_date(t, dir = :next, can_nudge_month = true); end
 
-  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(T.nilable(Integer))  }
+  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(T.nilable(Integer))  }
   def nudge_hour(t, dir = :next); end
 
-  sig { params(t: InternalTime[SourceClass, Source], dir: Symbol).returns(T.nilable(Integer))  }
+  sig { params(t: InternalTime[T.class_of(Time), Time], dir: Symbol).returns(T.nilable(Integer))  }
   def nudge_minute(t, dir = :next); end
 
   sig { returns(T::Hash[Symbol, [T::Set[Integer], T::Array[Integer], String]]) }
@@ -113,19 +97,16 @@ class CronParser::InternalTime
   extend T::Sig
   extend T::Generic
 
-  SourceClass = type_member
-  Source = type_member
-
   sig { returns(Integer) }
   attr_accessor :year, :month, :day, :hour, :min
 
-  sig { returns(SourceClass) }
+  sig { returns(T.class_of(Time)) }
   attr_accessor :time_source
 
-  sig { params(time: Source, time_source: SourceClass).void }
+  sig { params(time: Time, time_source: T.class_of(Time)).void }
   def initialize(time, time_source = Time); end
 
-  sig { returns(Source) }
+  sig { returns(Time) }
   def to_time; end
 
   sig { returns(String) }

--- a/lib/parse-cron/all/parse-cron_test.rb
+++ b/lib/parse-cron/all/parse-cron_test.rb
@@ -13,7 +13,7 @@ module ParseCronTest
   result_time = cron.last
   result_time = cron.last(reference_time)
 
-  # Generic usage
+  # Custom Time class
   ExtendedTime = Class.new(Time)
   result_time = CronParser.new("* * * * *", ExtendedTime).next
 end

--- a/lib/parse-cron/all/parse-cron_test.rb
+++ b/lib/parse-cron/all/parse-cron_test.rb
@@ -1,0 +1,19 @@
+# typed: strict
+
+module ParseCronTest
+  extend T::Sig
+
+  # Basic usage
+  reference_time = Time.now
+  cron = CronParser.new('* * * * *')
+
+  result_time = T.let(Time.now, Time)
+  result_time = cron.next
+  result_time = cron.next(reference_time)
+  result_time = cron.last
+  result_time = cron.last(reference_time)
+
+  # Generic usage
+  ExtendedTime = Class.new(Time)
+  result_time = CronParser.new("* * * * *", ExtendedTime).next
+end


### PR DESCRIPTION
I'm starting the types for https://github.com/siebertm/parse-cron. It's not as popular as the other gems in here, but I had fun typing it, and maybe someone else will find it useful.

The library makes some effort to support a few features that make it difficult to type, so I'd especially appreciate feedback on these points:
1. An alternate provider of `Time.now` and `Time.local` (`time_source`). I handled this with generics, but the documentation for those is stil in progress. Are user-facing generics stable enough to be used in this repo?
2. Some methods (`next` and `last`) are overloaded to return different types depending on the value of their arguments. My understanding is that user-facing overloads are not planned. So I chose to type the simpler signature (because that's all I really need) and left the complicated one in as a comment. Would you recommend something different?
3. There are a few tuple types in here. The [tuple docs](https://sorbet.org/docs/tuples) mention that they're experimental. Are they too experimental for shared RBIs like this?