### PR TITLE
Fix RBI for ActionDispatch::Routing get + lambda

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -451,7 +451,7 @@ module ActionDispatch::Routing::Mapper::HttpHelpers
       module: T.nilable(T.any(String, Symbol)),
       as: T.nilable(T.any(String, Symbol)),
       via: T.nilable(T.any(Symbol, T::Array[Symbol])),
-      to: T.nilable(T.any(String, Symbol, T.proc.returns(T.untyped))),
+      to: T.nilable(T.any(String, Symbol, T.proc.params(arg0: T.untyped).returns(T.untyped))),
       on: T.nilable(Symbol),
       constraints: T.untyped,
       defaults: T.nilable(T::Hash[T.untyped, T.untyped]),


### PR DESCRIPTION
This is a small fix for ActionDispatch::Routing::Mapper::HttpHelpers#get.

When called with a lambda it requires a parameter, which is `env`.

In my app I have to call it like this:
```ruby
get 'something', to: -> (env) { ... }
```

If no parameter is passed it results in an error:
```ruby
get 'something', to: -> { ... }
```
```
     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # ./config/routes.rb:376:in `block (2 levels) in <main>'
```
