### PR TITLE
Fix stripe.rbi

### DIFF
--- a/lib/stripe/all/stripe.rbi
+++ b/lib/stripe/all/stripe.rbi
@@ -73,7 +73,7 @@ module Stripe
     sig { returns(String) }
     def id; end
 
-    sig { returns(val: T::Hash[Symbol, T.untyped]) }
+    sig { returns(T::Hash[Symbol, T.untyped]) }
     def metadata; end
 
     sig { void.params(val: T::Hash[Symbol, T.untyped]) }


### PR DESCRIPTION
The change fixes error
```
sorbet/rbi/sorbet-typed/lib/stripe/all/stripe.rbi:83: returns does not accept keyword arguments https://srb.help/5003                                          
    83 |    sig { returns(val: T::Hash[Symbol, T.untyped]) }                                                                                                   
```
for sorbet 0.5.6014.