### PR TITLE
Changed activestorage after_commit sig to accept proc too as first arg

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1029,7 +1029,7 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: Symbol,
+      arg: T.any(Symbol, T.proc.returns(T.untyped)),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -68,6 +68,7 @@ class ActiveRecordCallbacksTest < ApplicationRecord
   after_commit :log_commit_action
   after_commit :log_user_saved_to_db, on: :create
   after_commit :log_user_saved_to_db, on: [:create, :update]
+  after_commit -> { :log_user_saved_to_db }, on: [:create, :update]
 
   before_validation :validation_setup
   before_validation :validation_setup, on: :create


### PR DESCRIPTION
`after_commit` callback accepts a proc/lambda as the first argument