### PR TITLE
Fix up methods with incorrect param types in activesupport.rbi

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -949,7 +949,7 @@ module DateAndTime::Calculations
   sig { returns(T.self_type) }
   def at_beginning_of_quarter; end
 
-  sig { params(start_day: Integer).returns(T.self_type) }
+  sig { params(start_day: Symbol).returns(T.self_type) }
   def at_beginning_of_week(start_day = T.unsafe(nil)); end
 
   sig { returns(T.self_type) }
@@ -961,7 +961,7 @@ module DateAndTime::Calculations
   sig { returns(T.self_type) }
   def at_end_of_quarter; end
 
-  sig { params(start_day: Integer).returns(T.self_type) }
+  sig { params(start_day: Symbol).returns(T.self_type) }
   def at_end_of_week(start_day = T.unsafe(nil)); end
 
   sig { returns(T.self_type) }
@@ -976,7 +976,7 @@ module DateAndTime::Calculations
   sig { returns(T.self_type) }
   def beginning_of_quarter; end
 
-  sig { params(start_day: Integer).returns(T.self_type) }
+  sig { params(start_day: Symbol).returns(T.self_type) }
   def beginning_of_week(start_day = T.unsafe(nil)); end
 
   sig { returns(T.self_type) }
@@ -988,7 +988,7 @@ module DateAndTime::Calculations
   sig { params(days: Numeric).returns(T.self_type) }
   def days_since(days); end
 
-  sig { params(start_day: Integer).returns(T.self_type) }
+  sig { params(start_day: Symbol).returns(T.self_type) }
   def days_to_week_start(start_day = T.unsafe(nil)); end
 
   sig { returns(T.self_type) }
@@ -997,7 +997,7 @@ module DateAndTime::Calculations
   sig { returns(T.self_type) }
   def end_of_quarter; end
 
-  sig { params(start_day: Integer).returns(T.self_type) }
+  sig { params(start_day: Symbol).returns(T.self_type) }
   def end_of_week(start_day = T.unsafe(nil)); end
 
   sig { returns(T.self_type) }
@@ -1012,7 +1012,7 @@ module DateAndTime::Calculations
   sig { returns(T.self_type) }
   def last_quarter; end
 
-  sig { params(start_day: Integer, same_time: T::Boolean).returns(T.self_type) }
+  sig { params(start_day: Symbol, same_time: T::Boolean).returns(T.self_type) }
   def last_week(start_day = T.unsafe(nil), same_time: T.unsafe(nil)); end
 
   sig { returns(T.self_type) }
@@ -1030,13 +1030,13 @@ module DateAndTime::Calculations
   sig { params(months: Numeric).returns(T.self_type) }
   def months_since(months); end
 
-  sig { params(day_of_week: Integer).returns(T.self_type) }
+  sig { params(day_of_week: Symbol).returns(T.self_type) }
   def next_occurring(day_of_week); end
 
   sig { returns(T.self_type) }
   def next_quarter; end
 
-  sig { params(given_day_in_next_week: Integer, same_time: T::Boolean).returns(T.self_type) }
+  sig { params(given_day_in_next_week: Symbol, same_time: T::Boolean).returns(T.self_type) }
   def next_week(given_day_in_next_week = T.unsafe(nil), same_time: T.unsafe(nil)); end
 
   sig { returns(T.self_type) }
@@ -1051,13 +1051,13 @@ module DateAndTime::Calculations
   sig { returns(T::Boolean) }
   def past?; end
 
-  sig { params(day_of_week: Integer).returns(T.self_type) }
+  sig { params(day_of_week: Symbol).returns(T.self_type) }
   def prev_occurring(day_of_week); end
 
   sig { returns(T.self_type) }
   def prev_quarter; end
 
-  sig { params(start_day: Integer, same_time: T::Boolean).returns(T.self_type) }
+  sig { params(start_day: Symbol, same_time: T::Boolean).returns(T.self_type) }
   def prev_week(start_day = T.unsafe(nil), same_time: T.unsafe(nil)); end
 
   sig { returns(T.self_type) }


### PR DESCRIPTION
Fixes methods that are defined to accept an `Integer` as an argument but actually accept a `Symbol` representing a day of the week i.e. `:monday`, `:tuesday`, etc.

Methods updated with links to rails source
**Note**: [`Date.beginning_of_week`](https://github.com/rails/rails/blob/fac52ee506097e7b97501c50e13c0782549f1410/activesupport/lib/active_support/core_ext/date/calculations.rb#L19) returns a `Symbol`
- [`beginning_of_week`/`at_beginning_of_week`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L257)
- [`end_of_week`/`at_end_of_week`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L273)
- [`days_to_week_start`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L248)
- [`last_week`/`prev_week`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L213)
- [`next_occurring`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L330)
- [`prev_occurring`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L341)
- [`next_week`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L190)
- [`prev_week`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L213)