### PR TITLE
Fix sig for rescue_from in active_support.rbi

### DIFF
--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -2768,7 +2768,7 @@ module ActiveSupport::Rescuable::ClassMethods
   def handler_for_rescue(exception, object: T.unsafe(nil)); end
 
   # https://github.com/rails/rails/blob/5-2-stable/activesupport/lib/active_support/rescuable.rb#L51
-  sig { params(klasses: Class, with: T.nilable(Symbol), block: T.nilable(T.proc.void)).void }
+  sig { params(klasses: Class, with: T.nilable(Symbol), block: T.nilable(T.proc.params(error: T.untyped).void)).void }
   def rescue_from(*klasses, with: T.unsafe(nil), &block); end
 
   def rescue_with_handler(exception, object: T.unsafe(nil), visited_exceptions: T.unsafe(nil)); end


### PR DESCRIPTION
The block in `rescue_from` has an argument that is the rescued exception: https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from