### PR TITLE
Remove bad constant from activerecord.rbi

### DIFF
--- a/.ci/run.rb
+++ b/.ci/run.rb
@@ -11,7 +11,7 @@ gems = Dir.glob("lib/*").reject { |p| exclude.include?(p) }
 
 # some gems cross-reference constants from other gems. this is typical of Rails gems.
 # it's assumed that you'll never use just the one gem in isolation.
-# while this should be avoied, if absolutely necessary you can define dependencies here.
+# while this should be avoided, if absolutely necessary you can define dependencies here.
 # when running tests, all the values will also be required when testing the key.
 # (note that this is hard to identify when tests run because error 5002 (missing const) is ignored)
 deps = {

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -243,7 +243,6 @@ end
 
 module ActiveRecord::AttributeMethods
   extend(::ActiveSupport::Concern)
-  extend(::FilterEncryptedAttributes)
 
   include(::ActiveModel::AttributeMethods)
   include(::ActiveRecord::AttributeMethods::Read)


### PR DESCRIPTION
Fixes #307

In #291 I merged RBI from our codebase which accidentally included a reference to a home-rolled extension. Removing that reference here.