### PR TITLE
Doorkeeper 5.5 refactor

### DIFF
--- a/lib/doorkeeper/<5.5/doorkeeper.rbi
+++ b/lib/doorkeeper/<5.5/doorkeeper.rbi
@@ -1,0 +1,7 @@
+class Doorkeeper::OAuth::Authorization::Context
+  def initialize(client, grant_type, scopes); end
+
+  def client; end
+  def grant_type; end
+  def scopes; end
+end

--- a/lib/doorkeeper/>=5.5/doorkeeper.rbi
+++ b/lib/doorkeeper/>=5.5/doorkeeper.rbi
@@ -1,0 +1,8 @@
+class Doorkeeper::OAuth::Authorization::Context
+  def initialize(**attributes); end
+
+  def client; end
+  def grant_type; end
+  def resource_owner; end
+  def scopes; end
+end

--- a/lib/doorkeeper/>=5/doorkeeper.rbi
+++ b/lib/doorkeeper/>=5/doorkeeper.rbi
@@ -510,14 +510,6 @@ class Doorkeeper::OAuth::Authorization::Code
   def pkce_supported?; end
 end
 
-class Doorkeeper::OAuth::Authorization::Context
-  def initialize(client, grant_type, scopes); end
-
-  def client; end
-  def grant_type; end
-  def scopes; end
-end
-
 class Doorkeeper::OAuth::Authorization::Token
   def initialize(pre_auth, resource_owner); end
 


### PR DESCRIPTION
[This initializer](https://github.com/doorkeeper-gem/doorkeeper/pull/1421/files#diff-7fb5547c84ba954804c79874d49b268181877c68e39f7e5405fb66398c9241baR9) was changed in Doorkeeper 5.5.

cc @jeffcarbs since you added the original rbi [a few days ago](https://github.com/sorbet/sorbet-typed/pull/308)