### PR TITLE
Update lib/actionpack/all/actionpack.rbi

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -304,6 +304,123 @@ class ActionController::ActionControllerError < ::StandardError
 end
 
 class ActionController::API < ::ActionController::Metal
+  include(::ActionView::ViewPaths)
+  include(::AbstractController::Rendering)
+  include(::ActionDispatch::Routing::PolymorphicRoutes)
+  include(::ActionDispatch::Routing::UrlFor)
+  include(::AbstractController::UrlFor)
+  include(::ActionController::UrlFor)
+  include(::AbstractController::Logger)
+  include(::ActiveSupport::Benchmarkable)
+  include(::ActionController::Redirecting)
+  include(::ActionController::ApiRendering)
+  include(::ActionController::Rendering)
+  include(::ActionController::Renderers)
+  include(::ActionController::Renderers::All)
+  include(::ActionController::Head)
+  include(::ActionController::ConditionalGet)
+  include(::ActionController::BasicImplicitRender)
+  include(::ActionController::StrongParameters)
+  include(::ActiveSupport::Callbacks)
+  include(::AbstractController::Callbacks)
+  include(::ActionController::ForceSSL)
+  include(::ActionController::DataStreaming)
+  include(::ActionController::DefaultHeaders)
+  include(::ActiveSupport::Rescuable)
+  include(::ActionController::Rescue)
+  include(::ActionController::Instrumentation)
+  include(::ActionController::ParamsWrapper)
+  include(::ActionController::RespondWith)
+  extend(::ActionView::ViewPaths::ClassMethods)
+  extend(::AbstractController::UrlFor::ClassMethods)
+  extend(::ActionController::Rendering::ClassMethods)
+  extend(::ActionController::Renderers::ClassMethods)
+  extend(::ActionController::ConditionalGet::ClassMethods)
+  extend(::ActiveSupport::Callbacks::ClassMethods)
+  extend(::AbstractController::Callbacks::ClassMethods)
+  extend(::ActionController::ForceSSL::ClassMethods)
+  extend(::ActionController::DefaultHeaders::ClassMethods)
+  extend(::ActiveSupport::Rescuable::ClassMethods)
+  extend(::ActionController::Instrumentation::ClassMethods)
+  extend(::ActionController::ParamsWrapper::ClassMethods)
+  extend(::ActionController::RespondWith::ClassMethods)
+
+  def __callbacks; end
+  def __callbacks?; end
+  def _cancan_skipper; end
+  def _cancan_skipper=(val); end
+  def _cancan_skipper?; end
+  def _process_action_callbacks; end
+  def _renderers; end
+  def _renderers=(val); end
+  def _renderers?; end
+  def _run_process_action_callbacks(&block); end
+  def _wrapper_options; end
+  def _wrapper_options=(val); end
+  def _wrapper_options?; end
+  def default_url_options; end
+  def default_url_options=(val); end
+  def default_url_options?; end
+  def etaggers; end
+  def etaggers=(val); end
+  def etaggers?; end
+  def logger; end
+  def logger=(value); end
+  def mimes_for_respond_to; end
+  def mimes_for_respond_to=(val); end
+  def mimes_for_respond_to?; end
+  def rescue_handlers; end
+  def rescue_handlers=(val); end
+  def rescue_handlers?; end
+  def responder; end
+  def responder=(val); end
+  def responder?; end
+
+  class << self
+    def __callbacks; end
+    def __callbacks=(val); end
+    def __callbacks?; end
+    def _cancan_skipper; end
+    def _cancan_skipper=(val); end
+    def _cancan_skipper?; end
+    def _process_action_callbacks; end
+    def _process_action_callbacks=(value); end
+    def _renderers; end
+    def _renderers=(val); end
+    def _renderers?; end
+    def _wrapper_options; end
+    def _wrapper_options=(val); end
+    def _wrapper_options?; end
+    def default_url_options; end
+    def default_url_options=(val); end
+    def default_url_options?; end
+    def etaggers; end
+    def etaggers=(val); end
+    def etaggers?; end
+    def logger; end
+    def logger=(value); end
+    def middleware_stack; end
+    def mimes_for_respond_to; end
+    def mimes_for_respond_to=(val); end
+    def mimes_for_respond_to?; end
+    def rescue_handlers; end
+    def rescue_handlers=(val); end
+    def rescue_handlers?; end
+    def responder; end
+    def responder=(val); end
+    def responder?; end
+    def without_modules(*modules); end
+  end
+end
+
+ActionController::API::MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
+
+module ActionController::ApiRendering
+  extend(::ActiveSupport::Concern)
+
+  include(::ActionController::Rendering)
+
+  def render_to_body(options = T.unsafe(nil)); end
 end
 
 module ::AbstractController::Rendering; end


### PR DESCRIPTION
Update RBI for `ActionController::API` in actionpack.rbi. The definition of this class (and some supporting classes) were generated via `tapioca generate`.