### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
There's not a lot in this repo to suggest or enforce formatting, please allow me to humbly suggest this `.editorconfig` file as a small step. (I believe this is consistent with rubocop defaults, in case that's desirable.)