### PR TITLE
add `array` option to `add_column` on activerecord

### DIFF
--- a/lib/activerecord/~>5.2.0/activerecord_test.rb
+++ b/lib/activerecord/~>5.2.0/activerecord_test.rb
@@ -45,6 +45,7 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
 
     add_column :products, :price, :decimal, precision: 5, scale: 2
     add_column :articles, :status, :string, limit: 20, default: 'draft', null: false
+    add_column :articles, :tags, :string, array: true, default: []
     add_column :answers, :bill_gates_money, :decimal, precision: 15, scale: 2
     add_column :measurements, :sensor_reading, :decimal, precision: 30, scale: 20
     add_column :measurements, :huge_integer, :decimal, precision: 30

--- a/lib/activerecord/~>6.0.0/activerecord.rbi
+++ b/lib/activerecord/~>6.0.0/activerecord.rbi
@@ -148,7 +148,8 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
       null: T::Boolean,
       precision: Integer,
       scale: Integer,
-      comment: String
+      comment: String,
+      array: T::Boolean
     ).void
   end
   def add_column(
@@ -160,7 +161,8 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     null: nil,
     precision: nil,
     scale: nil,
-    comment: nil
+    comment: nil,
+    array: nil
   ); end
 
   sig do

--- a/lib/activerecord/~>6.0.0/activerecord_test.rb
+++ b/lib/activerecord/~>6.0.0/activerecord_test.rb
@@ -49,6 +49,7 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
 
     add_column :products, :price, :decimal, precision: 5, scale: 2
     add_column :articles, :status, :string, limit: 20, default: 'draft', null: false
+    add_column :articles, :tags, :string, array: true, default: []
     add_column :answers, :bill_gates_money, :decimal, precision: 15, scale: 2
     add_column :measurements, :sensor_reading, :decimal, precision: 30, scale: 20
     add_column :measurements, :huge_integer, :decimal, precision: 30

--- a/lib/activerecord/~>6.1.0.rc1/activerecord.rbi
+++ b/lib/activerecord/~>6.1.0.rc1/activerecord.rbi
@@ -150,7 +150,8 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
       null: T::Boolean,
       precision: Integer,
       scale: Integer,
-      comment: String
+      comment: String,
+      array: T::Boolean
     ).void
   end
   def add_column(
@@ -162,7 +163,8 @@ class ActiveRecord::Migration::Current < ActiveRecord::Migration
     null: nil,
     precision: nil,
     scale: nil,
-    comment: nil
+    comment: nil,
+    array: nil
   ); end
 
   sig do

--- a/lib/activerecord/~>6.1.0.rc1/activerecord_test.rb
+++ b/lib/activerecord/~>6.1.0.rc1/activerecord_test.rb
@@ -49,6 +49,7 @@ class ActiveRecordMigrationsTest < ActiveRecord::Migration::Current
 
     add_column :products, :price, :decimal, precision: 5, scale: 2
     add_column :articles, :status, :string, limit: 20, default: 'draft', null: false
+    add_column :articles, :tags, :string, array: true, default: []
     add_column :answers, :bill_gates_money, :decimal, precision: 15, scale: 2
     add_column :measurements, :sensor_reading, :decimal, precision: 30, scale: 20
     add_column :measurements, :huge_integer, :decimal, precision: 30


### PR DESCRIPTION
This was currently only valid on `activerecord ~> 5.2.0`, however, this is also available on `activerecord 6.0` and `6.1`.

This was added to `activerecord ~> 5.2.0` on #231.

Rails Guide:
- https://guides.rubyonrails.org/v6.0.0/active_record_postgresql.html#array
- https://guides.rubyonrails.org/v6.1.0/active_record_postgresql.html#array