### PR TITLE
Fix bad parent classes in ActiveRecord error classes.

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1694,7 +1694,6 @@ module ActiveRecord
   class PreparedStatementCacheExpired < StatementInvalid; end
   class PreparedStatementInvalid < ActiveRecordError; end
   class ProtectedEnvironmentError < ActiveRecordError; end
-  class QueryCanceled < StatementInvalid; end
   class RangeError < StatementInvalid; end
   class ReadOnlyRecord < ActiveRecordError; end
 
@@ -1711,7 +1710,6 @@ module ActiveRecord
   class SerializationTypeMismatch < ActiveRecordError; end
   class StaleObjectError < ActiveRecordError; end
   class StatementInvalid < ActiveRecordError; end
-  class StatementTimeout < StatementInvalid; end
   class SubclassNotFound < ActiveRecordError; end
   class ThroughCantAssociateThroughHasOneOrManyReflection < ActiveRecordError; end
   class ThroughNestedAssociationsAreReadonly < ActiveRecordError; end

--- a/lib/activerecord/~>6.1.0.rc1/activerecord.rbi
+++ b/lib/activerecord/~>6.1.0.rc1/activerecord.rbi
@@ -485,3 +485,11 @@ module ActiveRecord::ConnectionHandling
   def connects_to(database: T.unsafe(nil)); end
   def current_role; end
 end
+
+# In ActiveRecord >= 6.1, the parent classes of these errors have changed.
+# https://github.com/rails/rails/commit/730d810b0dd24e80c1e88d56a5e6960363a25dbb
+module ActiveRecord
+  class StatementTimeout < QueryAborted; end
+  class QueryCanceled < QueryAborted; end
+  class QueryAborted < StatementInvalid; end
+end


### PR DESCRIPTION
This commit changed the super classes for some ActiveRecord errors: https://github.com/rails/rails/commit/730d810b0dd24e80c1e88d56a5e6960363a25dbb

I removed the errors from activerecord.rbi because otherwise I'd need to create a `<= 6.1` RBI and that doesn't seem worth the trouble.