### PR TITLE
Fix rake.rbi

### DIFF
--- a/lib/rake/all/rake.rbi
+++ b/lib/rake/all/rake.rbi
@@ -633,6 +633,6 @@ module Rake::Backtrace
   def self.collapse(backtrace); end
 end
 class Rake::TaskLib
-  include Cloneable
+  include Rake::Cloneable
   include Rake::DSL
 end


### PR DESCRIPTION
The change fixes error
```
sorbet/rbi/sorbet-typed/lib/rake/all/rake.rbi:643: Unable to resolve constant Cloneable https://srb.help/5002
     643 |  include Cloneable
```