### PR TITLE
Fix incorrect ActiveRecord signatures and add tests.

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -2429,20 +2429,20 @@ class ActiveRecord::Relation
   def empty?; end
 
   # Returns true if there are no records.
-  sig { returns(T::Boolean) }
-  def none?; end
+  sig { params(block: T.nilable(T.proc.params(arg0: Elem).returns(T::Boolean))).returns(T::Boolean) }
+  def none?(&block); end
 
   # Returns true if there are any records.
-  sig { returns(T::Boolean) }
-  def any?; end
+  sig { params(block: T.nilable(T.proc.params(arg0: Elem).returns(T::Boolean))).returns(T::Boolean) }
+  def any?(&block); end
 
   # Returns true if there is exactly one record.
-  sig { returns(T::Boolean) }
-  def one?; end
+  sig { params(block: T.nilable(T.proc.params(arg0: Elem).returns(T::Boolean))).returns(T::Boolean) }
+  def one?(&block); end
 
   # Returns true if there is more than one record.
-  sig { returns(T::Boolean) }
-  def many?; end
+  sig { params(block: T.nilable(T.proc.params(arg0: Elem).returns(T::Boolean))).returns(T::Boolean) }
+  def many?(&block); end
 end
 
 module ActiveRecord::Store

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1054,82 +1054,19 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.any(Symbol, T.proc.returns(T.untyped)),
+      arg: T.nilable(T.any(Symbol, T.proc.returns(T.untyped))),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
     ).void
   end
   def self.after_commit(
-    arg,
+    arg = nil,
     if: nil,
     on: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.after_create(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.after_destroy(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.after_rollback(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.after_save(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.after_update(
-    arg = nil,
-    if: nil,
-    unless: nil
+    unless: nil,
+    &block
   ); end
 
   sig do
@@ -1137,79 +1074,91 @@ class ActiveRecord::Base
       arg: T.nilable(Symbol),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      on: T.nilable(T.any(Symbol, T::Array[Symbol]))
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.after_create(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.after_destroy(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.after_rollback(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.after_save(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.after_update(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      on: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      block: T.nilable(T.proc.void)
     ).void
   end
   def self.after_validation(
     arg = nil,
     if: nil,
     unless: nil,
-    on: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.around_create(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.around_destroy(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.around_save(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.around_update(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.before_create(
-    arg = nil,
-    if: nil,
-    unless: nil
+    on: nil,
+    &block
   ); end
 
   sig do
@@ -1217,40 +1166,91 @@ class ActiveRecord::Base
       arg: T.nilable(Symbol),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      prepend: T::Boolean
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.around_create(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.around_destroy(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.around_save(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.around_update(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.before_create(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      prepend: T::Boolean,
+      block: T.nilable(T.proc.void)
     ).void
   end
   def self.before_destroy(
     arg = nil,
     if: nil,
     unless: nil,
-    prepend: false
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.before_save(
-    arg = nil,
-    if: nil,
-    unless: nil
-  ); end
-
-  sig do
-    params(
-      arg: T.nilable(Symbol),
-      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-    ).void
-  end
-  def self.before_update(
-    arg = nil,
-    if: nil,
-    unless: nil
+    prepend: false,
+    &block
   ); end
 
   sig do
@@ -1258,14 +1258,46 @@ class ActiveRecord::Base
       arg: T.nilable(Symbol),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      on: T.nilable(T.any(Symbol, T::Array[Symbol]))
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.before_save(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
+  end
+  def self.before_update(
+    arg = nil,
+    if: nil,
+    unless: nil,
+    &block
+  ); end
+
+  sig do
+    params(
+      arg: T.nilable(Symbol),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      on: T.nilable(T.any(Symbol, T::Array[Symbol])),
+      block: T.nilable(T.proc.void)
     ).void
   end
   def self.before_validation(
     arg = nil,
     if: nil,
     unless: nil,
-    on: nil
+    on: nil,
+    &block
   ); end
 
   sig { params(comparison_object: T.untyped).returns(T::Boolean) }

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -50,30 +50,45 @@ class ActiveRecordCallbacksTest < ApplicationRecord
   before_save :normalize_card_number, if: :paid_with_card?
   before_save :normalize_card_number, if: Proc.new { |order| order.paid_with_card? }
   before_save :log_save_action
+  before_save { puts 'foo' }
   around_save :log_save_action
+  around_save { puts 'foo' }
   after_save :log_save_action
+  after_save { puts 'foo' }
 
   before_destroy :log_destroy_action, prepend: true
+  before_destroy { puts 'foo' }
   around_destroy :log_destroy_action
+  around_destroy { puts 'foo' }
   after_destroy :log_destroy_action
+  after_destroy { puts 'foo' }
 
   before_update :log_update_action
+  before_update { puts 'foo' }
   around_update :log_update_action
+  around_update { puts 'foo' }
   after_update :log_update_action
+  after_update { puts 'foo' }
 
   before_create :log_create_action
+  before_create { puts 'foo' }
   around_create :log_create_action
+  around_create { puts 'foo' }
   after_create :log_create_action
+  after_create { puts 'foo' }
   after_create :send_email_to_author, if: :author_wants_emails?, unless: Proc.new { |comment| comment.article.ignore_comments? }
 
   after_commit :log_commit_action
+  after_commit { puts 'foo' }
   after_commit :log_user_saved_to_db, on: :create
   after_commit :log_user_saved_to_db, on: [:create, :update]
   after_commit -> { :log_user_saved_to_db }, on: [:create, :update]
 
   before_validation :validation_setup
+  before_validation { puts 'foo' }
   before_validation :validation_setup, on: :create
   after_validation :validation_teardown
+  after_validation { puts 'foo' }
   after_validation :validation_teardown, on: [:create, :update]
 
   def do_the_thing

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -189,6 +189,11 @@ class ActiveRecordMigrationsTest
     T.assert_type!(relation.one?, T::Boolean)
     T.assert_type!(relation.none?, T::Boolean)
     T.assert_type!(relation.size, Integer)
+
+    relation.any? { |record| true }
+    relation.many? { |record| true }
+    relation.one? { |record| true }
+    relation.none? { |record| true }
   end
 end
 


### PR DESCRIPTION
This fixes an issue with these type signatures that started to show up after the change to enforce block parameter declaration a few days ago. See also https://github.com/chanzuckerberg/sorbet-rails/issues/406