### PR TITLE
Remove untyped methods from activerecord.rbi

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -35,25 +35,7 @@ module ActiveRecord::Serialization; end
 module ActiveRecord::Store; end
 
 module ActiveRecord::Associations
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::Associations::ClassMethods)
-
-  def association(name); end
-  def association_cached?(name); end
-  def reload(*_); end
-
-  private
-
-  def association_instance_get(name); end
-  def association_instance_set(name, association); end
-  def clear_association_cache; end
-  def init_internals; end
-  def initialize_dup(*_); end
-
-  class << self
-    def eager_load!; end
-  end
 end
 
 module ActiveRecord::Associations::ClassMethods
@@ -244,661 +226,76 @@ module ActiveRecord::AttributeMethods::Serialization::ClassMethods
 end
 
 module ActiveRecord::AttributeMethods
-  extend(::ActiveSupport::Concern)
-
-  include(::ActiveModel::AttributeMethods)
-  include(::ActiveRecord::AttributeMethods::Read)
-  include(::ActiveRecord::AttributeMethods::Write)
-  include(::ActiveRecord::AttributeMethods::BeforeTypeCast)
-  include(::ActiveRecord::AttributeMethods::Query)
-  include(::ActiveRecord::AttributeMethods::PrimaryKey)
-  include(::ActiveRecord::AttributeMethods::TimeZoneConversion)
-  include(::ActiveModel::Dirty)
-  include(::ActiveRecord::AttributeMethods::Dirty)
-  include(::ActiveRecord::AttributeMethods::Serialization)
-
   mixes_in_class_methods(::ActiveRecord::AttributeMethods::ClassMethods)
-
-  def [](attr_name); end
-  def []=(attr_name, value); end
-  def accessed_fields; end
-  def attribute_for_inspect(attr_name); end
-  def attribute_names; end
-  def attribute_present?(attribute); end
-  def attributes; end
-  def attributes_without_attr_encrypted; end
-  def has_attribute?(attr_name); end
-  def respond_to?(name, include_private = T.unsafe(nil)); end
-
-  private
-
-  def attribute_method?(attr_name); end
-  def attributes_for_create(attribute_names); end
-  def attributes_for_update(attribute_names); end
-  def attributes_with_values(attribute_names); end
-  def format_for_inspect(value); end
-  def pk_attribute?(name); end
-  def readonly_attribute?(name); end
 end
 
-module ActiveRecord::AttributeMethods::BeforeTypeCast
-  extend(::ActiveSupport::Concern)
-
-  def attributes_before_type_cast; end
-  def read_attribute_before_type_cast(attr_name); end
-
-  private
-
-  def attribute_before_type_cast(attribute_name); end
-  def attribute_came_from_user?(attribute_name); end
-end
-
-module ActiveRecord::AttributeMethods::ClassMethods
-  def attribute_method?(attribute); end
-  def attribute_names; end
-  def class_method_defined_within?(name, klass, superklass = T.unsafe(nil)); end
-  def column_for_attribute(name); end
-  def dangerous_attribute_method?(name); end
-  def dangerous_class_method?(method_name); end
-  def define_attribute_methods; end
-  def has_attribute?(attr_name); end
-  def inherited(child_class); end
-  def initialize_generated_modules; end
-  def instance_method_already_implemented?(method_name); end
-  def method_defined_within?(name, klass, superklass = T.unsafe(nil)); end
-  def undefine_attribute_methods; end
-end
-
-module ActiveRecord::AttributeMethods::Dirty
-  extend(::ActiveSupport::Concern)
-
-  include(::ActiveModel::AttributeMethods)
-  include(::ActiveModel::Dirty)
-
-  def attribute_before_last_save(attr_name); end
-  def attribute_change_to_be_saved(attr_name); end
-  def attribute_in_database(attr_name); end
-  def attributes_in_database; end
-  def changed_attribute_names_to_save; end
-  def changes_to_save; end
-  def has_changes_to_save?; end
-  def reload(*_); end
-  def saved_change_to_attribute(attr_name); end
-  def saved_change_to_attribute?(attr_name, **options); end
-  def saved_changes; end
-  def saved_changes?; end
-  def will_save_change_to_attribute?(attr_name, **options); end
-
-  private
-
-  def _create_record(attribute_names = T.unsafe(nil)); end
-  def _touch_row(attribute_names, time); end
-  def _update_record(attribute_names = T.unsafe(nil)); end
-  def attribute_names_for_partial_writes; end
-  def mutations_before_last_save; end
-  def mutations_from_database; end
-  def write_attribute_without_type_cast(attr_name, value); end
-end
-
-class ActiveRecord::AttributeMethods::GeneratedAttributeMethods < ::Module
-  include(::Mutex_m)
-
-  def lock; end
-  def locked?; end
-  def synchronize(&block); end
-  def try_lock; end
-  def unlock; end
-end
+module ActiveRecord::AttributeMethods::ClassMethods; end
 
 module ActiveRecord::AttributeMethods::PrimaryKey
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods)
-
-  def id; end
-  def id=(value); end
-  def id?; end
-  def id_before_type_cast; end
-  def id_in_database; end
-  def id_was; end
-  def to_key; end
-
-  private
-
-  def attribute_method?(attr_name); end
 end
 
-module ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods
-  def dangerous_attribute_method?(method_name); end
-  def get_primary_key(base_name); end
-  def instance_method_already_implemented?(method_name); end
-  def primary_key; end
-  def primary_key=(value); end
-  def quoted_primary_key; end
-  def reset_primary_key; end
-
-  private
-
-  def suppress_composite_primary_key(pk); end
-end
+module ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods; end
 
 ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods::ID_ATTRIBUTE_METHODS = T.let(T.unsafe(nil), T::Set[T.untyped])
-
-module ActiveRecord::AttributeMethods::Query
-  extend(::ActiveSupport::Concern)
-
-  def query_attribute(attr_name); end
-
-  private
-
-  def attribute?(attribute_name); end
-end
 
 ActiveRecord::AttributeMethods::RESTRICTED_CLASS_METHODS = T.let(T.unsafe(nil), T::Array[T.untyped])
 
 module ActiveRecord::AttributeMethods::Read
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::AttributeMethods::Read::ClassMethods)
-
-  def _read_attribute(attr_name, &block); end
-  def read_attribute(attr_name, &block); end
-
-  private
-
-  def attribute(attr_name, &block); end
 end
 
-module ActiveRecord::AttributeMethods::Read::ClassMethods
-
-  private
-
-  def define_method_attribute(name); end
-end
+module ActiveRecord::AttributeMethods::Read::ClassMethods; end
 
 module ActiveRecord::AttributeMethods::Serialization
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::AttributeMethods::Serialization::ClassMethods)
 end
 
-module ActiveRecord::AttributeMethods::Serialization::ClassMethods
-  def serialize(attr_name, class_name_or_coder = T.unsafe(nil)); end
-
-  private
-
-  def type_incompatible_with_serialize?(type, class_name); end
-end
-
-class ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError < ::StandardError
-  def initialize(name, type); end
-end
+module ActiveRecord::AttributeMethods::Serialization::ClassMethods; end
 
 module ActiveRecord::AttributeMethods::TimeZoneConversion
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::AttributeMethods::TimeZoneConversion::ClassMethods)
 end
 
-module ActiveRecord::AttributeMethods::TimeZoneConversion::ClassMethods
-
-  private
-
-  def create_time_zone_conversion_attribute?(name, cast_type); end
-  def inherited(subclass); end
-end
-
-class ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
-  def cast(value); end
-  def deserialize(value); end
-
-  private
-
-  def convert_time_to_time_zone(value); end
-  def map_avoiding_infinite_recursion(value); end
-  def set_time_zone_without_conversion(value); end
-end
+module ActiveRecord::AttributeMethods::TimeZoneConversion::ClassMethods; end
 
 module ActiveRecord::AttributeMethods::Write
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::AttributeMethods::Write::ClassMethods)
-
-  def _write_attribute(attr_name, value); end
-  def write_attribute(attr_name, value); end
-
-  private
-
-  def attribute=(attribute_name, value); end
-  def write_attribute_without_type_cast(attr_name, value); end
 end
 
-module ActiveRecord::AttributeMethods::Write::ClassMethods
-
-  private
-
-  def define_method_attribute=(name); end
-end
+module ActiveRecord::AttributeMethods::Write::ClassMethods; end
 
 module ActiveRecord::AutosaveAssociation
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::AutosaveAssociation::ClassMethods)
-
-  def changed_for_autosave?; end
-  def destroyed_by_association; end
-  def destroyed_by_association=(reflection); end
-  def mark_for_destruction; end
-  def marked_for_destruction?; end
-  def reload(options = T.unsafe(nil)); end
-
-  private
-
-  def _ensure_no_duplicate_errors; end
-  def after_save_collection_association; end
-  def associated_records_to_validate_or_save(association, new_record, autosave); end
-  def association_foreign_key_changed?(reflection, record, key); end
-  def association_valid?(reflection, record, index = T.unsafe(nil)); end
-  def before_save_collection_association; end
-  def custom_validation_context?; end
-  def nested_records_changed_for_autosave?; end
-  def normalize_reflection_attribute(indexed_attribute, reflection, index, attribute); end
-  def record_changed?(reflection, record, key); end
-  def save_belongs_to_association(reflection); end
-  def save_collection_association(reflection); end
-  def save_has_one_association(reflection); end
-  def validate_collection_association(reflection); end
-  def validate_single_association(reflection); end
 end
 
-module ActiveRecord::AutosaveAssociation::AssociationBuilderExtension
-  class << self
-    def build(model, reflection); end
-    def valid_options; end
-  end
-end
-
-module ActiveRecord::AutosaveAssociation::ClassMethods
-
-  private
-
-  def add_autosave_association_callbacks(reflection); end
-  def define_autosave_validation_callbacks(reflection); end
-  def define_non_cyclic_method(name, &block); end
-end
-
-module ActiveRecord::ConnectionHandling
-  def clear_active_connections!(*_, &_); end
-  def clear_all_connections!(*_, &_); end
-  def clear_cache!; end
-  def clear_query_caches_for_current_thread; end
-  def clear_reloadable_connections!(*_, &_); end
-  def connected?; end
-  def connection; end
-  def connection_config; end
-  def connection_pool; end
-  def connection_specification_name; end
-  def connection_specification_name=(_); end
-  def establish_connection(config_or_env = T.unsafe(nil)); end
-  def flush_idle_connections!(*_, &_); end
-  def lookup_connection_handler(handler_key); end
-  def primary_class?; end
-  def remove_connection(name = T.unsafe(nil)); end
-  def resolve_config_for_connection(config_or_env); end
-  def retrieve_connection; end
-  def with_handler(handler_key, &blk); end
-
-  private
-
-  def swap_connection_handler(handler, &blk); end
-end
+module ActiveRecord::AutosaveAssociation::ClassMethods; end
 
 module ActiveRecord::Core
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::Core::ClassMethods)
-
-  def initialize(attributes = T.unsafe(nil)); end
-
-  def <=>(other_object); end
-  def ==(comparison_object); end
-  def blank?; end
-  def connection_handler; end
-  def encode_with(coder); end
-  def eql?(comparison_object); end
-  def freeze; end
-  def frozen?; end
-  def hash; end
-  def init_with(coder, &block); end
-  def init_with_attributes(attributes, new_record = T.unsafe(nil)); end
-  def inspect; end
-  def present?; end
-  def pretty_print(pp); end
-  def readonly!; end
-  def readonly?; end
-  def slice(*methods); end
-
-  private
-
-  def custom_inspect_method_defined?; end
-  def init_internals; end
-  def initialize_dup(other); end
-  def initialize_internals_callback; end
-  def inspection_filter; end
-  def to_ary; end
 end
 
-module ActiveRecord::Core::ClassMethods
-  def ===(object); end
-  def _internal?; end
-  def arel_attribute(name, table = T.unsafe(nil)); end
-  def arel_table; end
-  def filter_attributes; end
-  def filter_attributes=(_); end
-  def find(*ids); end
-  def find_by(*args); end
-  def find_by!(*args); end
-  def generated_association_methods; end
-  def inherited(child_class); end
-  def initialize_find_by_cache; end
-  def initialize_generated_modules; end
-  def inspect; end
-  def predicate_builder; end
-  def type_caster; end
-
-  private
-
-  def cached_find_by_statement(key, &block); end
-  def relation; end
-  def table_metadata; end
-end
+module ActiveRecord::Core::ClassMethods; end
 
 module ActiveRecord::Tasks::DatabaseTasks
   extend(::ActiveRecord::Tasks::DatabaseTasks)
-
-  def cache_dump_filename(namespace); end
-  def charset(*arguments); end
-  def charset_current(environment = T.unsafe(nil), specification_name = T.unsafe(nil)); end
-  def check_protected_environments!; end
-  def check_schema_file(filename); end
-  def check_target_version; end
-  def collation(*arguments); end
-  def collation_current(environment = T.unsafe(nil), specification_name = T.unsafe(nil)); end
-  def create(*arguments); end
-  def create_all; end
-  def create_current(environment = T.unsafe(nil), spec_name = T.unsafe(nil)); end
-  def current_config(options = T.unsafe(nil)); end
-  def current_config=(_); end
-  def database_configuration; end
-  def database_configuration=(_); end
-  def db_dir; end
-  def db_dir=(_); end
-  def drop(*arguments); end
-  def drop_all; end
-  def drop_current(environment = T.unsafe(nil)); end
-  def dump_filename(namespace, format = T.unsafe(nil)); end
-  def dump_schema(configuration, format = T.unsafe(nil), spec_name = T.unsafe(nil)); end
-  def dump_schema_cache(conn, filename); end
-  def env; end
-  def env=(_); end
-  def fixtures_path; end
-  def fixtures_path=(_); end
-  def for_each(databases); end
-  def load_schema(configuration, format = T.unsafe(nil), file = T.unsafe(nil), environment = T.unsafe(nil), spec_name = T.unsafe(nil)); end
-  def load_schema_current(format = T.unsafe(nil), file = T.unsafe(nil), environment = T.unsafe(nil)); end
-  def load_seed; end
-  def migrate; end
-  def migrate_status; end
-  def migrations_paths; end
-  def migrations_paths=(_); end
-  def purge(configuration); end
-  def purge_all; end
-  def purge_current(environment = T.unsafe(nil)); end
-  def raise_for_multi_db(environment = T.unsafe(nil), command:); end
-  def reconstruct_from_schema(configuration, format = T.unsafe(nil), file = T.unsafe(nil), environment = T.unsafe(nil), spec_name = T.unsafe(nil)); end
-  def register_task(pattern, task); end
-  def root; end
-  def root=(_); end
-  def schema_file(format = T.unsafe(nil)); end
-  def schema_file_type(format = T.unsafe(nil)); end
-  def schema_up_to_date?(configuration, format = T.unsafe(nil), file = T.unsafe(nil), environment = T.unsafe(nil), spec_name = T.unsafe(nil)); end
-  def seed_loader; end
-  def seed_loader=(_); end
-  def setup_initial_database_yaml; end
-  def spec; end
-  def structure_dump(*arguments); end
-  def structure_load(*arguments); end
-  def target_version; end
-  def truncate_all(environment = T.unsafe(nil)); end
-
-  private
-
-  def class_for_adapter(adapter); end
-  def each_current_configuration(environment, spec_name = T.unsafe(nil)); end
-  def each_local_configuration; end
-  def local_database?(configuration); end
-  def schema_sha1(file); end
-  def truncate_tables(configuration); end
-  def verbose?; end
-
-  class << self
-    def structure_dump_flags; end
-    def structure_dump_flags=(obj); end
-    def structure_load_flags; end
-    def structure_load_flags=(obj); end
-  end
 end
 
 ActiveRecord::Tasks::DatabaseTasks::LOCAL_HOSTS = T.let(T.unsafe(nil), T::Array[T.untyped])
 
 module ActiveRecord::Delegation
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::Delegation::ClassMethods)
-
-  def &(*_, &_); end
-  def +(*_, &_); end
-  def -(*_, &_); end
-  def [](*_, &_); end
-  def as_json(*_, &_); end
-  def compact(*_, &_); end
-  def connection(*_, &_); end
-  def each(*_, &_); end
-  def encode_with(*_, &_); end
-  def in_groups(*_, &_); end
-  def in_groups_of(*_, &_); end
-  def index(*_, &_); end
-  def join(*_, &_); end
-  def length(*_, &_); end
-  def primary_key(*_, &_); end
-  def reverse(*_, &_); end
-  def rindex(*_, &_); end
-  def rotate(*_, &_); end
-  def sample(*_, &_); end
-  def shuffle(*_, &_); end
-  def slice(*_, &_); end
-  def split(*_, &_); end
-  def to_formatted_s(*_, &_); end
-  def to_sentence(*_, &_); end
-  def to_xml(*_, &_); end
-  def |(*_, &_); end
-
-  private
-
-  def respond_to_missing?(method, _); end
 end
 
-module ActiveRecord::Delegation::ClassMethods
-  def create(klass, *args, **kwargs); end
-
-  private
-
-  def relation_class_for(klass); end
-end
+module ActiveRecord::Delegation::ClassMethods; end
 
 module ActiveRecord::Delegation::ClassSpecificRelation
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::Delegation::ClassSpecificRelation::ClassMethods)
-
-
-  private
-
-  def method_missing(method, *args, &block); end
 end
 
-module ActiveRecord::Delegation::ClassSpecificRelation::ClassMethods
-  def name; end
-end
-
-module ActiveRecord::Delegation::DelegateCache
-  def generate_relation_method(method); end
-  def inherited(child_class); end
-  def initialize_relation_delegate_cache; end
-  def relation_delegate_class(klass); end
-
-  protected
-
-  def include_relation_methods(delegate); end
-
-  private
-
-  def generated_relation_methods; end
-end
-
-module ActiveRecord::Enum
-  def enum(definitions); end
-  def inherited(base); end
-
-  private
-
-  def _enum_methods_module; end
-  def assert_valid_enum_definition_values(values); end
-  def detect_enum_conflict!(enum_name, method_name, klass_method = T.unsafe(nil)); end
-  def detect_negative_condition!(method_name); end
-  def raise_conflict_error(enum_name, method_name, type: T.unsafe(nil), source: T.unsafe(nil)); end
-
-  class << self
-    def extended(base); end
-  end
-end
-
-class ActiveRecord::Enum::EnumType < ::ActiveModel::Type::Value
-  def initialize(name, mapping, subtype); end
-
-  def assert_valid_value(value); end
-  def cast(value); end
-  def deserialize(value); end
-  def serialize(value); end
-  def type(*_, &_); end
-
-  private
-
-  def mapping; end
-  def name; end
-  def subtype; end
-end
-
-class ActiveRecord::Generators::Base < ::Rails::Generators::NamedBase
-  include ActiveRecord::Generators::Migration
-
-  class << self
-    def base_root; end
-  end
-end
-
-module ActiveRecord::Generators::Migration
-  extend ActiveSupport::Concern
-  include Rails::Generators::Migration
-
-  private
-
-  def primary_key_type; end
-  def db_migrate_path; end
-  def default_migrate_path; end
-  def configured_migrate_path; end
-end
-
-module ActiveRecord::Generators::Migration::ClassMethods
-  def next_migration_number(dirname); end
-end
+module ActiveRecord::Delegation::ClassSpecificRelation::ClassMethods; end
 
 ActiveRecord::Migration::MigrationFilenameRegexp = T.let(T.unsafe(nil), Regexp)
-
-class ActiveRecord::MigrationProxy < ::Struct
-  Elem = type_member(fixed: T.untyped)
-
-  def initialize(name, version, filename, scope); end
-
-  def announce(*_, &_); end
-  def basename; end
-  def disable_ddl_transaction(*_, &_); end
-  def filename; end
-  def filename=(_); end
-  def migrate(*_, &_); end
-  def mtime; end
-  def name; end
-  def name=(_); end
-  def scope; end
-  def scope=(_); end
-  def version; end
-  def version=(_); end
-  def write(*_, &_); end
-
-  private
-
-  def load_migration; end
-  def migration; end
-
-  class << self
-    def [](*_); end
-    def inspect; end
-    def members; end
-    def new(*_); end
-  end
-end
-
-class ActiveRecord::Migrator
-  def initialize(direction, migrations, schema_migration, target_version = T.unsafe(nil)); end
-
-  def current; end
-  def current_migration; end
-  def current_version; end
-  def load_migrated; end
-  def migrate; end
-  def migrated; end
-  def migrations; end
-  def pending_migrations; end
-  def run; end
-  def runnable; end
-
-  private
-
-  def ddl_transaction(migration); end
-  def down?; end
-  def execute_migration_in_transaction(migration, direction); end
-  def finish; end
-  def generate_migrator_advisory_lock_id; end
-  def invalid_target?; end
-  def migrate_without_lock; end
-  def ran?(migration); end
-  def record_environment; end
-  def record_version_state_after_migrating(version); end
-  def run_without_lock; end
-  def start; end
-  def target; end
-  def up?; end
-  def use_advisory_lock?; end
-  def use_transaction?(migration); end
-  def validate(migrations); end
-  def with_advisory_lock; end
-
-  class << self
-    def current_version; end
-    def migrations_paths; end
-    def migrations_paths=(_); end
-  end
-end
 
 ActiveRecord::Migrator::MIGRATOR_SALT = T.let(T.unsafe(nil), Integer)
 
@@ -922,41 +319,15 @@ module ActiveRecord::NestedAttributes::ClassMethods
 end
 
 module ActiveRecord::ReadonlyAttributes
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::ReadonlyAttributes::ClassMethods)
 end
 
-module ActiveRecord::ReadonlyAttributes::ClassMethods
-  def attr_readonly(*attributes); end
-  def readonly_attributes; end
-end
-
-module ActiveRecord::Scoping::Default::ClassMethods
-  def before_remove_const; end
-  def scope_attributes?; end
-  def unscoped; end
-
-  private
-
-  def build_default_scope(relation = T.unsafe(nil)); end
-  def default_scope(scope = T.unsafe(nil), &block); end
-  def evaluate_default_scope; end
-  def ignore_default_scope=(ignore); end
-  def ignore_default_scope?; end
-end
-
+module ActiveRecord::ReadonlyAttributes::ClassMethods; end
 module ActiveRecord::Scoping::Named
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::Scoping::Named::ClassMethods)
 end
 
 module ActiveRecord::Scoping::Named::ClassMethods
-  def all; end
-  def default_extensions; end
-  def default_scoped(scope = T.unsafe(nil)); end
-
   sig do
     params(
       name: T.nilable(T.any(Symbol, String)),
@@ -965,12 +336,6 @@ module ActiveRecord::Scoping::Named::ClassMethods
     ).void
   end
   def scope(name, body, &block); end
-
-  def scope_for_association(scope = T.unsafe(nil)); end
-
-  private
-
-  def valid_scope_name?(name); end
 end
 
 module ActiveRecord::Inheritance
@@ -979,15 +344,6 @@ end
 
 module ActiveRecord::Transactions
   mixes_in_class_methods(ActiveRecord::Transactions::ClassMethods)
-end
-
-module ActiveRecord::Validations::ClassMethods
-  def validates_absence_of(*attr_names); end
-  def validates_associated(*attr_names); end
-  def validates_length_of(*attr_names); end
-  def validates_presence_of(*attr_names); end
-  def validates_size_of(*attr_names); end
-  def validates_uniqueness_of(*attr_names); end
 end
 
 class ActiveRecord::Base
@@ -1014,7 +370,6 @@ class ActiveRecord::Base
   include ActiveRecord::Inheritance
   include ActiveRecord::Scoping
   include ActiveRecord::Scoping::Default # via ActiveRecord::Scoping#included hook
-  extend ActiveRecord::Scoping::Default::ClassMethods # via ActiveRecord::Scoping::Default Concern inclusion
   include ActiveRecord::Scoping::Named # via ActiveRecord::Scoping#included hook
   extend ActiveRecord::Scoping::Named::ClassMethods # via ActiveRecord::Scoping::Named Concern inclusion
   include ActiveRecord::AttributeAssignment
@@ -1022,7 +377,6 @@ class ActiveRecord::Base
   include ActiveRecord::Integration
   include ActiveModel::Validations
   include ActiveModel::Validations::HelperMethods
-  extend ActiveRecord::Validations::ClassMethods
   include ActiveRecord::CounterCache
   include ActiveRecord::Attributes
   include ActiveRecord::AttributeDecorators
@@ -1463,16 +817,6 @@ module ActiveRecord::Persistence
         T::Hash[T.any(Symbol, String), T.untyped],
         ActionController::Parameters
       )
-    ).returns(T::Boolean)
-  end
-  def update_attributes(attributes); end
-
-  sig do
-    params(
-      attributes: T.any(
-        T::Hash[T.any(Symbol, String), T.untyped],
-        ActionController::Parameters
-      )
     ).void
   end
   def assign_attributes(attributes); end
@@ -1594,31 +938,6 @@ end
 class ActiveRecord::Result
   include(::Enumerable)
   Elem = type_member(fixed: T.untyped)
-
-  def initialize(columns, rows, column_types = T.unsafe(nil)); end
-
-  def [](idx); end
-  def cast_values(type_overrides = T.unsafe(nil)); end
-  def collect!; end
-  def column_types; end
-  def columns; end
-  def each; end
-  def empty?; end
-  def first; end
-  def includes_column?(name); end
-  def last; end
-  def length; end
-  def map!; end
-  def rows; end
-  def to_a; end
-  def to_ary; end
-  def to_hash; end
-
-  private
-
-  def column_type(name, type_overrides = T.unsafe(nil)); end
-  def hash_rows; end
-  def initialize_copy(other); end
 end
 
 ActiveRecord::Type::BigInteger = ActiveModel::Type::BigInteger
@@ -1632,19 +951,6 @@ ActiveRecord::Type::String = ActiveModel::Type::String
 ActiveRecord::Type::String = ActiveModel::Type::String
 ActiveRecord::Type::Value = ActiveModel::Type::Value
 ActiveRecord::Type::Value = ActiveModel::Type::Value
-
-module ActiveRecord::Type::Internal::Timezone
-  def default_timezone; end
-  def is_utc?; end
-end
-
-class ActiveRecord::Type::Date < ::ActiveModel::Type::Date
-  include(::ActiveRecord::Type::Internal::Timezone)
-end
-
-class ActiveRecord::Type::DateTime < ::ActiveModel::Type::DateTime
-  include(::ActiveRecord::Type::Internal::Timezone)
-end
 
 module ActiveRecord
   class ActiveRecordError < StandardError; end
@@ -1739,30 +1045,6 @@ end
 
 module ActiveRecord::Associations
   mixes_in_class_methods(ActiveRecord::Associations::ClassMethods)
-end
-
-module ActiveRecord::Coders
-end
-
-class ActiveRecord::Coders::JSON
-  class << self
-    def dump(obj); end
-    def load(json); end
-  end
-end
-
-class ActiveRecord::Coders::YAMLColumn
-  def initialize(attr_name, object_class = T.unsafe(nil)); end
-
-  def assert_valid_value(obj, action:); end
-  def dump(obj); end
-  def load(yaml); end
-  def object_class; end
-  def object_class=(_); end
-
-  private
-
-  def check_arity_of_constructor; end
 end
 
 # Represents the schema of an SQL table in an abstract way. This class
@@ -1862,66 +1144,6 @@ class ActiveRecord::ConnectionAdapters::TableDefinition
   # ```
   sig { params(args: T.untyped, options: T.untyped).void }
   def belongs_to(*args, **options); end
-end
-
-class ActiveRecord::ConnectionAdapters::Column
-  def initialize(name, default, sql_type_metadata = T.unsafe(nil), null = T.unsafe(nil), default_function = T.unsafe(nil), collation: T.unsafe(nil), comment: T.unsafe(nil), **_); end
-
-  def ==(other); end
-  def bigint?; end
-  def collation; end
-  def comment; end
-  def default; end
-  def default_function; end
-  def encode_with(coder); end
-  def eql?(other); end
-  def has_default?; end
-  def hash; end
-  def human_name; end
-  def init_with(coder); end
-  def limit(*_, &_); end
-  def name; end
-  def null; end
-  def precision(*_, &_); end
-  def scale(*_, &_); end
-  def sql_type(*_, &_); end
-  def sql_type_metadata; end
-  def type(*_, &_); end
-end
-
-class ActiveRecord::ConnectionAdapters::ColumnDefinition < ::Struct
-  Elem = type_member(fixed: T.untyped)
-
-  def collation; end
-  def collation=(value); end
-  def comment; end
-  def comment=(value); end
-  def default; end
-  def default=(value); end
-  def limit; end
-  def limit=(value); end
-  def name; end
-  def name=(_); end
-  def null; end
-  def null=(value); end
-  def options; end
-  def options=(_); end
-  def precision; end
-  def precision=(value); end
-  def primary_key?; end
-  def scale; end
-  def scale=(value); end
-  def sql_type; end
-  def sql_type=(_); end
-  def type; end
-  def type=(_); end
-
-  class << self
-    def [](*_); end
-    def inspect; end
-    def members; end
-    def new(*_); end
-  end
 end
 
 module ActiveRecord::ConnectionAdapters::ColumnMethods
@@ -2090,37 +1312,6 @@ module ActiveRecord::ConnectionAdapters::ColumnMethods
     ).void
   end
   def virtual(*names, index: nil, default: nil, **options); end
-end
-
-class ActiveRecord::ConnectionAdapters::ConnectionHandler
-  def initialize; end
-
-  def active_connections?; end
-  def clear_active_connections!; end
-  def clear_all_connections!; end
-  def clear_reloadable_connections!; end
-  def connected?(spec_name); end
-  def connection_pool_list; end
-  def connection_pools; end
-  def establish_connection(config); end
-  def flush_idle_connections!; end
-  def prevent_writes; end
-  def prevent_writes=(prevent_writes); end
-  def remove_connection(spec_name); end
-  def retrieve_connection(spec_name); end
-  def retrieve_connection_pool(spec_name); end
-  def while_preventing_writes(enabled = T.unsafe(nil)); end
-
-  private
-
-  def owner_to_pool; end
-  def pool_from_any_process_for(spec_name); end
-
-  class << self
-    def create_owner_to_pool; end
-    def discard_unowned_pools(pid_map); end
-    def unowned_pool_finalizer(pid_map); end
-  end
 end
 
 # Represents an SQL table in an abstract way for updating a table.
@@ -2370,47 +1561,7 @@ module ActiveRecord::Locking::Pessimistic
   def with_lock(lock = nil, &blk); end
 end
 
-class ActiveRecord::LogSubscriber < ::ActiveSupport::LogSubscriber
-  def backtrace_cleaner; end
-  def backtrace_cleaner=(val); end
-  def backtrace_cleaner?; end
-  def sql(event); end
-
-  private
-
-  def colorize_payload_name(name, payload_name); end
-  def debug(progname = T.unsafe(nil), &block); end
-  def extract_query_source_location(locations); end
-  def log_query_source; end
-  def logger; end
-  def render_bind(attr, value); end
-  def sql_color(sql); end
-  def type_casted_binds(casted_binds); end
-
-  class << self
-    def backtrace_cleaner; end
-    def backtrace_cleaner=(val); end
-    def backtrace_cleaner?; end
-    def reset_runtime; end
-    def runtime; end
-    def runtime=(value); end
-  end
-end
-
 ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES = T.let(T.unsafe(nil), T::Array[T.untyped])
-
-class ActiveRecord::Associations::Preloader
-  def preload(records, associations, preload_scope = T.unsafe(nil)); end
-
-  private
-
-  def grouped_records(association, records, polymorphic_parent); end
-  def preloader_for(reflection, owners); end
-  def preloaders_for_hash(association, records, scope, polymorphic_parent); end
-  def preloaders_for_one(association, records, scope, polymorphic_parent); end
-  def preloaders_for_reflection(reflection, records, scope); end
-  def preloaders_on(association, records, scope, polymorphic_parent = T.unsafe(nil)); end
-end
 
 class ActiveRecord::Relation
   sig { returns(Integer) }
@@ -2446,24 +1597,7 @@ class ActiveRecord::Relation
 end
 
 module ActiveRecord::Store
-  extend(::ActiveSupport::Concern)
-
   mixes_in_class_methods(::ActiveRecord::Store::ClassMethods)
-
-  private
-
-  def read_store_attribute(store_attribute, key); end
-  def store_accessor_for(store_attribute); end
-  def write_store_attribute(store_attribute, key, value); end
 end
 
-module ActiveRecord::Store::ClassMethods
-  def _store_accessors_module; end
-  def store(store_attribute, options = T.unsafe(nil)); end
-  def store_accessor(store_attribute, *keys, prefix: T.unsafe(nil), suffix: T.unsafe(nil)); end
-  def stored_attributes; end
-end
-
-module ActiveRecord::Batches; end
-
-class ActiveRecord::Batches::BatchEnumerator; end
+module ActiveRecord::Store::ClassMethods; end


### PR DESCRIPTION
No reason to have all these methods, they only make maintaining forward/backward compatibility more difficult for no benefit.

If you want to know all the methods that exist in ActiveRecord, you should be generating gem RBIs with Sorbet or Tapioca.

I've left in mixes_in_class_methods usages, to make sure that this commit doesn't remove anything that `srb rbi gems` wouldn't know about itself.

This resolves a lot of issues with the RBI (e.g. different arguments between these sigs and the actual methods in rails).