### PR TITLE
Add missed Elem to ActiveRecord::Relation

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1601,6 +1601,8 @@ end
 ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES = T.let(T.unsafe(nil), T::Array[T.untyped])
 
 class ActiveRecord::Relation
+  Elem = type_member(fixed: T.untyped)
+
   sig { returns(Integer) }
   def delete_all; end
 


### PR DESCRIPTION
Seems `Elem` type member is missed in `ActiveRecord::Relation`. The PR adds it.

The issue is not detected by the tests because of `--suppress-error-code 5002` `sorbet tc` option.

In a real project (in my case) there may be an error:
```
sorbet/rbi/sorbet-typed/lib/activerecord/all/activerecord.rbi:1624: type_member type Enumerable::Elem used outside of the class definition https://srb.help/502
7                                      
    1624 |  sig { params(block: T.nilable(T.proc.params(arg0: Elem).returns(T::Boolean))).returns(T::Boolean) }                                                
```
In my `hidden.rbi`, I have
```ruby
class ActiveRecord::Relation
  include ::Enumerable
  include ::ActiveRecord::Delegation
  ...
end
```

If we add `include Enumerable` into `ActiveRecord::Relation`, the tests will fail with the same errors.