### PR TITLE
Add bundler-audit

### DIFF
--- a/.ci/run.rb
+++ b/.ci/run.rb
@@ -17,6 +17,7 @@ gems = Dir.glob("lib/*").reject { |p| exclude.include?(p) }
 deps = {
   "lib/activerecord" => ["lib/activemodel", "lib/activesupport"],
   "lib/actionpack" => ["lib/activesupport"],
+  "lib/bundler-audit" => ["lib/rake"],
   "lib/rspec-core" => ["lib/rake"],
   "lib/rubocop" => ["lib/rake"],
 }

--- a/lib/bundler-audit/all/bundler-audit.rbi
+++ b/lib/bundler-audit/all/bundler-audit.rbi
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Bundler::Audit::Task < ::Rake::TaskLib
+end

--- a/lib/bundler-audit/all/bundler-audit_test.rb
+++ b/lib/bundler-audit/all/bundler-audit_test.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+# https://github.com/rubysec/bundler-audit/blob/119ee71f99e153e859968b154d7cb35bb51f9fb1/README.md#synopsis
+Bundler::Audit::Task.new


### PR DESCRIPTION
The bundler-audit rake [task](https://github.com/rubysec/bundler-audit/blob/master/lib/bundler/audit/task.rb) isn't picked up by the autogenerated shim:

https://github.com/dduugg/yard-sorbet/pull/40/files#diff-ca5e2ec0409c05b9e1b4203ca60e70276bdc9066889707fb8927a90bc172ba44
https://travis-ci.com/github/dduugg/yard-sorbet/jobs/505772008#L440-L441