### PR TITLE
Add YARD handlers

### DIFF
--- a/lib/yard/all/yard.rbi
+++ b/lib/yard/all/yard.rbi
@@ -769,6 +769,7 @@ class YARD::Handlers::Base
   def ensure_loaded!(object, max_retries = nil); end
   def extra_state; end
   def globals; end
+  def handlers; end
   def initialize(source_parser, stmt); end
   def namespace; end
   def namespace=(v); end
@@ -840,6 +841,8 @@ module YARD::Handlers::Ruby::StructHandlerMethods
   def return_type_from_tag(member_tag); end
   include YARD::CodeObjects
 end
+class YARD::Handlers::Ruby::AttributeHandler < YARD::Handlers::Ruby::Base
+end
 class YARD::Handlers::Ruby::ClassHandler < YARD::Handlers::Ruby::Base
   def create_struct_superclass(superclass, superclass_def); end
   def extract_parameters(superclass); end
@@ -848,6 +851,8 @@ class YARD::Handlers::Ruby::ClassHandler < YARD::Handlers::Ruby::Base
   def struct_superclass_name(superclass); end
   include Anonymous_Module_4
   include YARD::Handlers::Ruby::StructHandlerMethods
+end
+class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
 end
 module Anonymous_Module_4
   def process; end

--- a/lib/yard/all/yard_test.rb
+++ b/lib/yard/all/yard_test.rb
@@ -1,5 +1,13 @@
 # typed: strict
 
 YARD::CodeObjects::ClassObject.new(YARD::Registry.root, 'X::Y')
-
 # => #<yardoc class X::Y>
+
+YARD::Handlers::Ruby::AttributeHandler.handlers
+# => [#<YARD::Handlers::Ruby::MethodCallWrapper:0x00007f8b198e52a0 @name="attr">,
+#     #<YARD::Handlers::Ruby::MethodCallWrapper:0x00007f8b198e4fd0 @name="attr_reader">,
+#     #<YARD::Handlers::Ruby::MethodCallWrapper:0x00007f8b198e4dc8 @name="attr_writer">,
+#     #<YARD::Handlers::Ruby::MethodCallWrapper:0x00007f8b198e4c60 @name="attr_accessor">]
+
+YARD::Handlers::Ruby::MethodHandler.handlers
+# => [:def, :defs]


### PR DESCRIPTION
Adds a couple of missing handler classes and related method:

https://github.com/lsegal/yard/blame/main/lib/yard/handlers/ruby/attribute_handler.rb
https://github.com/lsegal/yard/blob/main/lib/yard/handlers/ruby/method_handler.rb
https://github.com/lsegal/yard/blob/main/lib/yard/handlers/base.rb#L211