### PR TITLE
Fix type signatures for after_*_commit in ActiveRecord.

### DIFF
--- a/lib/activerecord/>=5/activerecord.rbi
+++ b/lib/activerecord/>=5/activerecord.rbi
@@ -3,42 +3,48 @@
 class ActiveRecord::Base
 
   sig do
-  params(
-    arg: T.any(Symbol, T.proc.returns(T.untyped)),
-    if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-    unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-  ).void
+    params(
+      args: T.any(Symbol, T.proc.returns(T.untyped)),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
   end
   def self.after_create_commit(
-    arg,
+    *args,
     if: nil,
-    unless: nil
+    unless: nil,
+    &block
   ); end
 
   sig do
-  params(
-    arg: T.any(Symbol, T.proc.returns(T.untyped)),
-    if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-    unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-  ).void
+    params(
+      args: T.any(Symbol, T.proc.returns(T.untyped)),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
   end
   def self.after_update_commit(
-    arg,
+    *args,
     if: nil,
-    unless: nil
+    unless: nil,
+    &block
   ); end
 
   sig do
-  params(
-    arg: T.any(Symbol, T.proc.returns(T.untyped)),
-    if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-    unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean))))
-  ).void
+    params(
+      args: T.any(Symbol, T.proc.returns(T.untyped)),
+      if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
+      block: T.nilable(T.proc.void)
+    ).void
   end
   def self.after_destroy_commit(
-    arg,
+    *args,
     if: nil,
-    unless: nil
+    unless: nil,
+    &block
   ); end
 
   sig { params(attribute: T.any(Symbol, String)).void }

--- a/lib/activerecord/>=5/activerecord_test.rb
+++ b/lib/activerecord/>=5/activerecord_test.rb
@@ -3,13 +3,25 @@
 class ActiveRecordCallbacksTest < ApplicationRecord
 
   after_create_commit :log_create_commit_action
+  after_create_commit :action1, :action2
   after_create_commit :log_user_saved_to_db, if: :author_wants_emails?, unless: Proc.new { |comment| comment.article.ignore_comments? }
+  after_create_commit do
+    puts 'foo'
+  end
 
   after_update_commit :log_update_commit_action
+  after_update_commit :action1, :action2
   after_update_commit :log_user_saved_to_db, if: :author_wants_emails?, unless: Proc.new { |comment| comment.article.ignore_comments? }
+  after_update_commit do
+    puts 'foo'
+  end
 
   after_destroy_commit :log_destroy_commit_action
+  after_destroy_commit :action1, :action2
   after_destroy_commit :log_user_deleted_from_db, if: :author_wants_emails?, unless: Proc.new { |comment| comment.article.ignore_comments? }
+  after_destroy_commit do
+    puts 'foo'
+  end
 
   has_secure_token :secure_token
 end


### PR DESCRIPTION
Ran into this when trying to add Sorbet to a larger Rails app.

These methods takes a block and the first argument actually accepts multiple values. Updated the tests accordingly.

See the docs: https://api.rubyonrails.org/v5.2.0/classes/ActiveRecord/Transactions/ClassMethods.html#method-i-after_create_commit