### PR TITLE
Misc improvements

### DIFF
--- a/lib/activerecord/>=5/activerecord.rbi
+++ b/lib/activerecord/>=5/activerecord.rbi
@@ -7,7 +7,7 @@ class ActiveRecord::Base
       args: T.any(Symbol, T.proc.returns(T.untyped)),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_create_commit(
@@ -22,7 +22,7 @@ class ActiveRecord::Base
       args: T.any(Symbol, T.proc.returns(T.untyped)),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_update_commit(
@@ -37,7 +37,7 @@ class ActiveRecord::Base
       args: T.any(Symbol, T.proc.returns(T.untyped)),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_destroy_commit(

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -417,7 +417,7 @@ class ActiveRecord::Base
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_commit(
@@ -433,7 +433,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_create(
@@ -448,7 +448,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_destroy(
@@ -463,7 +463,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_rollback(
@@ -478,7 +478,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_save(
@@ -493,7 +493,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_update(
@@ -509,7 +509,7 @@ class ActiveRecord::Base
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.after_validation(
@@ -525,7 +525,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.around_create(
@@ -540,7 +540,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.around_destroy(
@@ -555,7 +555,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.around_save(
@@ -570,7 +570,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.around_update(
@@ -585,7 +585,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.before_create(
@@ -601,7 +601,7 @@ class ActiveRecord::Base
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       prepend: T::Boolean,
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.before_destroy(
@@ -617,7 +617,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.before_save(
@@ -632,7 +632,7 @@ class ActiveRecord::Base
       args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.before_update(
@@ -648,7 +648,7 @@ class ActiveRecord::Base
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
-      block: T.nilable(T.proc.void)
+      block: T.nilable(T.proc.bind(T.untyped).void)
     ).void
   end
   def self.before_validation(

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -413,7 +413,7 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(T.any(Symbol, T.proc.returns(T.untyped))),
+      args: T.any(Symbol, T.proc.returns(T.untyped)),
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
@@ -421,7 +421,7 @@ class ActiveRecord::Base
     ).void
   end
   def self.after_commit(
-    arg = nil,
+    *args,
     if: nil,
     on: nil,
     unless: nil,
@@ -430,14 +430,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.after_create(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -445,14 +445,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.after_destroy(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -460,14 +460,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.after_rollback(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -475,14 +475,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.after_save(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -490,14 +490,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.after_update(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -505,7 +505,7 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
@@ -513,7 +513,7 @@ class ActiveRecord::Base
     ).void
   end
   def self.after_validation(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     on: nil,
@@ -522,14 +522,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.around_create(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -537,14 +537,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.around_destroy(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -552,14 +552,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.around_save(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -567,14 +567,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.around_update(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -582,14 +582,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.before_create(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -597,7 +597,7 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       prepend: T::Boolean,
@@ -605,7 +605,7 @@ class ActiveRecord::Base
     ).void
   end
   def self.before_destroy(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     prepend: false,
@@ -614,14 +614,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.before_save(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -629,14 +629,14 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       block: T.nilable(T.proc.void)
     ).void
   end
   def self.before_update(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     &block
@@ -644,7 +644,7 @@ class ActiveRecord::Base
 
   sig do
     params(
-      arg: T.nilable(Symbol),
+      args: Symbol,
       if: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       unless: T.nilable(T.any(Symbol, Proc, T.proc.params(arg0: T.untyped).returns(T.nilable(T::Boolean)))),
       on: T.nilable(T.any(Symbol, T::Array[Symbol])),
@@ -652,7 +652,7 @@ class ActiveRecord::Base
     ).void
   end
   def self.before_validation(
-    arg = nil,
+    *args,
     if: nil,
     unless: nil,
     on: nil,

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -1076,7 +1076,7 @@ end
 
 module ActiveRecord::AttributeMethods::Dirty
   extend T::Sig
-  sig { params(attr_name: Symbol, options: T.untyped).returns(T::Boolean) }
+  sig { params(attr_name: T.any(String, Symbol), options: T.untyped).returns(T::Boolean) }
   def saved_change_to_attribute?(attr_name, **options); end
 end
 

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -65,44 +65,59 @@ class ActiveRecordCallbacksTest < ApplicationRecord
   before_save :normalize_card_number, if: :paid_with_card?
   before_save :normalize_card_number, if: Proc.new { |order| order.paid_with_card? }
   before_save :log_save_action
+  before_save :first_action, :second_action
   before_save { puts 'foo' }
   around_save :log_save_action
+  around_save :first_action, :second_action
   around_save { puts 'foo' }
   after_save :log_save_action
+  after_save :first_action, :second_action
   after_save { puts 'foo' }
 
   before_destroy :log_destroy_action, prepend: true
+  before_destroy :first_action, :second_action
   before_destroy { puts 'foo' }
   around_destroy :log_destroy_action
+  around_destroy :first_action, :second_action
   around_destroy { puts 'foo' }
   after_destroy :log_destroy_action
+  after_destroy :first_action, :second_action
   after_destroy { puts 'foo' }
 
   before_update :log_update_action
+  before_update :first_action, :second_action
   before_update { puts 'foo' }
   around_update :log_update_action
+  around_update :first_action, :second_action
   around_update { puts 'foo' }
   after_update :log_update_action
+  after_update :first_action, :second_action
   after_update { puts 'foo' }
 
   before_create :log_create_action
+  before_create :first_action, :second_action
   before_create { puts 'foo' }
   around_create :log_create_action
+  around_create :first_action, :second_action
   around_create { puts 'foo' }
   after_create :log_create_action
+  after_create :first_action, :second_action
   after_create { puts 'foo' }
   after_create :send_email_to_author, if: :author_wants_emails?, unless: Proc.new { |comment| comment.article.ignore_comments? }
 
   after_commit :log_commit_action
+  after_commit :first_action, :second_action
   after_commit { puts 'foo' }
   after_commit :log_user_saved_to_db, on: :create
   after_commit :log_user_saved_to_db, on: [:create, :update]
   after_commit -> { :log_user_saved_to_db }, on: [:create, :update]
 
   before_validation :validation_setup
+  before_validation :first_action, :second_action
   before_validation { puts 'foo' }
   before_validation :validation_setup, on: :create
   after_validation :validation_teardown
+  after_validation :first_action, :second_action
   after_validation { puts 'foo' }
   after_validation :validation_teardown, on: [:create, :update]
 


### PR DESCRIPTION
Fixes for a few different issues I've discovered trying to add Sorbet to a large Rails app.

- `after_*`, `before_*`, etc. callbacks accept more than one argument, which the types weren't handling correctly before.
- `T.proc.void` binds to the parent class rather than an instance of the class, and I couldn't figure out a way to implement this in an accurate way, so I've just made it bind to untyped instead.
- `saved_change_to_attribute?` accepts a string as well as a symbol.