### PR TITLE
Fix master

### DIFF
--- a/.ci/run.rb
+++ b/.ci/run.rb
@@ -20,6 +20,7 @@ deps = {
   "lib/bundler-audit" => ["lib/rake"],
   "lib/rspec-core" => ["lib/rake"],
   "lib/rubocop" => ["lib/rake"],
+  "lib/doorkeeper" => ["lib/activesupport", "lib/actionpack"],
 }
 
 results =

--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -162,6 +162,9 @@ module AbstractController::Callbacks::ClassMethods
   def skip_before_action(*names, except: nil, only: nil, if: nil, unless: nil, raise: true); end
 end
 
+class AbstractController::Base
+end
+
 module AbstractController::Helpers
   mixes_in_class_methods(::AbstractController::Helpers::ClassMethods)
 end
@@ -178,7 +181,9 @@ class ActionController::Base < ::ActionController::Metal
   include(::ActiveSupport::Rescuable)
 end
 
-ActionController::API::MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
+class ActionController::API
+  MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
+end
 
 ActionController::Base::MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
 

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -295,8 +295,6 @@ end
 
 module ActiveRecord::Delegation::ClassSpecificRelation::ClassMethods; end
 
-ActiveRecord::Migration::MigrationFilenameRegexp = T.let(T.unsafe(nil), Regexp)
-
 ActiveRecord::Migrator::MIGRATOR_SALT = T.let(T.unsafe(nil), Integer)
 
 module ActiveRecord::NestedAttributes::ClassMethods
@@ -1067,6 +1065,10 @@ module ActiveRecord
   class UnknownPrimaryKey < ActiveRecordError; end
   class ValueTooLong < StatementInvalid; end
   class WrappedDatabaseException < StatementInvalid; end
+end
+
+class ActiveRecord::Migration
+  MigrationFilenameRegexp = T.let(T.unsafe(nil), Regexp)
 end
 
 class ActiveRecord::Schema < ActiveRecord::Migration::Current


### PR DESCRIPTION
There were some classes without definitions used as superclasses, but sorbet was implicitly treating them as modules.