### PR TITLE
More stripe types

### DIFF
--- a/lib/minitest/all/minitest.rbi
+++ b/lib/minitest/all/minitest.rbi
@@ -58,9 +58,9 @@ module Minitest::Assertions
   sig do
     params(
       exp: T.untyped
-    ).returns(TrueClass)
+    ).returns(StandardError)
   end
-  def assert_raises(*exp); end
+  def assert_raises(*exp, &block); end
 
   sig { params(test: T.untyped, msg: T.nilable(String)).returns(TrueClass) }
   def refute(test, msg = nil); end


### PR DESCRIPTION
I'm not sure how to represent `period` correctly.

Returning StripeObject won't work since the returning object contains start/end, which StripeObject does not.

```
so = Stripe::StripeObject.construct_from({"start": 1626978473, "end": 1626978473})
so.start
so.end
```