### PR TITLE
Add type signature for ActionView::Helpers::FormBuilder#object

### DIFF
--- a/lib/actionview/all/actionview.rbi
+++ b/lib/actionview/all/actionview.rbi
@@ -46,6 +46,11 @@ ActionView::Helpers::DateTimeSelector::POSITION = T.let(T.unsafe(nil), T::Hash[T
 
 ActionView::Helpers::JavaScriptHelper::JS_ESCAPE_MAP = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 
+class ActionView::Helpers::FormBuilder
+  sig { returns(T.untyped) }
+  def object; end
+end
+
 module ActionView::Helpers::NumberHelper
   # These will return nil if given nil and a string otherwise. Ideally we'd be able to encode
   # that via sig overload but that's only supported for ruby stdlib.


### PR DESCRIPTION
Prevents this error:
```
$ srb tc
app/components/collections/update/participant_row_component.rb:20: Method object does not exist on ActionView::Helpers::FormBuilder https://srb.help/7003
    20 |        form.object
                ^^^^^^^^^^^
  Got ActionView::Helpers::FormBuilder originating from:
    app/components/collections/update/participant_row_component.rb:20:
    20 |        form.object
                ^^^^
  Autocorrect: Use `-a` to autocorrect
    app/components/collections/update/participant_row_component.rb:20: Replace with object_id
    20 |        form.object
                     ^^^^^^
Errors: 1
```