### PR TITLE
Run ci every night to try to exercise new sorbet changes

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
     branches: [ master ]
 
+  # Daily job that runs at 7AM UTC to test with the newest sorbet.
+  schedule:
+    - cron: '0 7 * * *'
+
 jobs:
   test:
 


### PR DESCRIPTION
Run ci at 7am UTC to exercise sorbet-typed on new changes from the newly published sorbet gems.