### PR TITLE
Update signature for activerecord transaction

### DIFF
--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -671,10 +671,11 @@ end
 
 module ActiveRecord::Transactions::ClassMethods
   sig do
-    params(
+    type_parameters(:T)
+    .params(
       options: T.nilable(T::Hash[T.any(Symbol, String), T.untyped]),
-      block: T.proc.returns(T.untyped)
-    ).returns(T.untyped)
+      block: T.proc.returns(T.type_parameter(:T))
+    ).returns(T.type_parameter(:T))
   end
   def transaction(options = {}, &block); end
 end

--- a/lib/activerecord/all/activerecord_test.rb
+++ b/lib/activerecord/all/activerecord_test.rb
@@ -218,11 +218,17 @@ class ActiveRecordMigrationsTest
   end
 
   def test_transactions
-    ActiveRecordCallbacksTest.transaction do
+    first_result = ActiveRecordCallbacksTest.transaction do
+      1
     end
 
-    ActiveRecordCallbacksTest.transaction(requires_new: true) do
+    T.assert_type!(first_result, Integer)
+
+    second_result = ActiveRecordCallbacksTest.transaction(requires_new: true) do
+      ['2']
     end
+
+    T.assert_type!(second_result, T::Array[String])
   end
 
   def test_activerecord_instance_methods


### PR DESCRIPTION
Update signature for activerecord transaction to return type of the block result.