### PR TITLE
Add additional parameters to aasm event

### DIFF
--- a/lib/aasm/all/aasm.rbi
+++ b/lib/aasm/all/aasm.rbi
@@ -26,8 +26,17 @@ module AASM::ClassMethods
   sig do
     params(
       name: Symbol,
-      after_commit: T.nilable(Symbol),
-      guard: T.nilable(Symbol),
+      after_commit: T.nilable(T::Array[Symbol]),
+      guard: T.nilable(T::Array[Symbol]),
+      unless: T.nilable(T::Array[Symbol]),
+      after: T.nilable(T::Array[Symbol]),
+      after_transition: T.nilable(T::Array[Symbol]),
+      before: T.nilable(T::Array[Symbol]),
+      before_transaction: T.nilable(T::Array[Symbol]),
+      ensure: T.nilable(T::Array[Symbol]),
+      error: T.nilable(T::Array[Symbol]),
+      before_success: T.nilable(T::Array[Symbol]),
+      success: T.nilable(T::Array[Symbol]),
       block: T.proc.bind(T.untyped).void
     ).void
   end
@@ -35,6 +44,15 @@ module AASM::ClassMethods
     name,
     after_commit: nil,
     guard: nil,
+    unless: nil,
+    after: nil,
+    after_transition: nil,
+    before: nil,
+    before_transaction: nil,
+    ensure: nil,
+    error: nil,
+    before_success: nil,
+    success: nil,
     &block
   )
   end


### PR DESCRIPTION
The list of the options I'm adding can be found [here](https://github.com/aasm/aasm/blob/master/lib/aasm/core/event.rb#L20).

Also updates `after_commit` and `guard` to be nillable arrays of Symbols instead of just nilable symbols.