### PR TITLE
Re-add definitions for AR::Migration[5.0]

### DIFF
--- a/lib/activerecord/~>7.0.0.alpha2/activerecord.rbi
+++ b/lib/activerecord/~>7.0.0.alpha2/activerecord.rbi
@@ -1,5 +1,6 @@
 # typed: strong
 
+class ActiveRecord::Migration::Compatibility::V5_0 < ActiveRecord::Migration::Compatibility::V5_1; end
 class ActiveRecord::Migration::Compatibility::V5_1 < ActiveRecord::Migration::Compatibility::V5_2; end
 
 # 5.2 has a different definition for create_table because 6.0 adds a new option.


### PR DESCRIPTION
Somehow these got removed and I was getting errors for a missing `add_column` definition. Adding this line fixed the problem.