### PR TITLE
Fix rails method signatures

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -1100,10 +1100,9 @@ module ActionDispatch::Routing::Mapper::Resources
     &block
   ); end
 
-  # Technically, path doesn't have a default value set. However, this is
-  # necessary to allow code like `root to: 'home#index'`.
-  sig { params(path: T.nilable(String), to: T.untyped, as: T.nilable(Symbol)).returns(T.untyped) }
-  def root(path = T.unsafe(nil), to: nil, as: nil); end
+  # Type path as Hash to support omitting path string and providing only options
+  sig { params(path: T.any(Hash, String), to: T.untyped, as: T.nilable(Symbol)).returns(T.untyped) }
+  def root(path, to: nil, as: nil); end
 
   sig { returns(T.untyped) }
   def shallow; end

--- a/lib/actionview/all/actionview.rbi
+++ b/lib/actionview/all/actionview.rbi
@@ -150,8 +150,8 @@ module ActionView::Helpers::UrlHelper
   # ```
   #
   # We can also pass in the symbol arguments instead of strings.
-  sig { params(options: T.untyped, check_parameters: T::Boolean).returns(T::Boolean) }
-  def current_page?(options, check_parameters: false); end
+  sig { params(options: T.untyped, check_parameters: T::Boolean, options_as_kwargs: T::Hash[T.untyped, T.untyped]).returns(T::Boolean) }
+  def current_page?(options, check_parameters: false, **options_as_kwargs); end
 
   # Creates an anchor element of the given `name` using a URL created by the set of `options`.
   # See the valid options in the documentation for `url_for`. It's also possible to

--- a/lib/activerecord/>=5.2/activerecord.rbi
+++ b/lib/activerecord/>=5.2/activerecord.rbi
@@ -20,3 +20,21 @@ end
 module ActiveRecord::DefineCallbacks::ClassMethods
   include(::ActiveModel::Callbacks)
 end
+
+module ActiveRecord::TouchLater
+  def touch_later(*names, **arg1); end
+end
+
+module ActiveRecord::SecureToken::ClassMethods
+  def generate_unique_secure_token; end
+  def has_secure_token(attribute = T.unsafe(nil)); end
+end
+
+module ActiveRecord::Suppressor
+  extend(::ActiveSupport::Concern)
+
+  mixes_in_class_methods(::ActiveRecord::Suppressor::ClassMethods)
+
+  def save(*arg0, **arg1); end
+  def save!(*arg0, **arg1); end
+end

--- a/lib/activerecord/>=5/activerecord.rbi
+++ b/lib/activerecord/>=5/activerecord.rbi
@@ -57,29 +57,14 @@ module ActiveRecord::SecureToken
   mixes_in_class_methods(::ActiveRecord::SecureToken::ClassMethods)
 end
 
-module ActiveRecord::Suppressor
-  extend(::ActiveSupport::Concern)
-
-  mixes_in_class_methods(::ActiveRecord::Suppressor::ClassMethods)
-
-  def save(*arg0, **arg1); end
-  def save!(*arg0, **arg1); end
-end
-
 module ActiveRecord::Suppressor::ClassMethods
   def suppress(&block); end
-end
-
-module ActiveRecord::SecureToken::ClassMethods
-  def generate_unique_secure_token; end
-  def has_secure_token(attribute = T.unsafe(nil)); end
 end
 
 module ActiveRecord::TouchLater
   extend(::ActiveSupport::Concern)
 
   def touch(*names, time: T.unsafe(nil)); end
-  def touch_later(*names, **arg1); end
 
   private
 

--- a/lib/activerecord/~>6.1.0.rc1/activerecord.rbi
+++ b/lib/activerecord/~>6.1.0.rc1/activerecord.rbi
@@ -480,9 +480,9 @@ module ActiveRecord::Core
 end
 
 module ActiveRecord::ConnectionHandling
-  def connected_to(database: T.unsafe(nil), role: T.unsafe(nil), prevent_writes: T.unsafe(nil), &blk); end
-  def connected_to?(role:); end
-  def connects_to(database: T.unsafe(nil)); end
+  def connected_to(database: T.unsafe(nil), role: T.unsafe(nil), shard: T.unsafe(nil), prevent_writes: T.unsafe(nil), &blk); end
+  def connected_to?(role: nil, shard: nil); end
+  def connects_to(database: T.unsafe({}), shards: T.unsafe({})); end
   def current_role; end
 end
 
@@ -492,4 +492,8 @@ module ActiveRecord
   class StatementTimeout < QueryAborted; end
   class QueryCanceled < QueryAborted; end
   class QueryAborted < StatementInvalid; end
+end
+
+module ActiveRecord::TouchLater
+  def touch_later(*names); end
 end


### PR DESCRIPTION
These incorrect method signatures were causing the rbis for the corresponding gems to be untyped. This fixes the typing issue for me.