### PR TITLE
Change `type_member` syntax to use block form

### DIFF
--- a/lib/activemodel/all/activemodel.rbi
+++ b/lib/activemodel/all/activemodel.rbi
@@ -561,7 +561,7 @@ ActiveModel::Validations::NumericalityValidator::RESERVED_OPTIONS = T.let(T.unsa
 
 class ActiveModel::Errors
   include Enumerable
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   sig { params(key: T.any(String, Symbol)).returns(T::Array[String]) }
   def [](key); end

--- a/lib/activerecord/all/activerecord.rbi
+++ b/lib/activerecord/all/activerecord.rbi
@@ -973,7 +973,7 @@ end
 
 class ActiveRecord::Result
   include(::Enumerable)
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 end
 
 ActiveRecord::Type::BigInteger = ActiveModel::Type::BigInteger
@@ -1604,7 +1604,7 @@ end
 ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES = T.let(T.unsafe(nil), T::Array[T.untyped])
 
 class ActiveRecord::Relation
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   sig { returns(Integer) }
   def delete_all; end

--- a/lib/activesupport/all/activesupport.rbi
+++ b/lib/activesupport/all/activesupport.rbi
@@ -543,9 +543,9 @@ module ActiveSupport::Inflector
 end
 
 class ActiveSupport::InheritableOptions < ::ActiveSupport::OrderedOptions
-  K = type_member(fixed: T.untyped)
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.untyped}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 
   def initialize(parent = T.unsafe(nil)); end
 
@@ -1760,9 +1760,9 @@ end
 module ActiveSupport::Configurable::ClassMethods; end
 
 class ActiveSupport::Configurable::Configuration < ::ActiveSupport::InheritableOptions
-  K = type_member(fixed: T.untyped)
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.untyped}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 end
 
 ActiveSupport::Deprecation::DEFAULT_BEHAVIORS = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
@@ -1779,9 +1779,9 @@ class ActiveSupport::DeprecationException < ::StandardError
 end
 
 class ActiveSupport::HashWithIndifferentAccess < Hash
-  K = type_member(fixed: T.any(String, Symbol))
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.any(String, Symbol)}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 end
 
 ActiveSupport::JSON::DATETIME_REGEX = T.let(T.unsafe(nil), Regexp)
@@ -1815,15 +1815,15 @@ ActiveSupport::Multibyte::Unicode::NORMALIZATION_FORM_ALIASES = T.let(T.unsafe(n
 ActiveSupport::Multibyte::Unicode::UNICODE_VERSION = T.let(T.unsafe(nil), String)
 
 class ActiveSupport::OrderedHash < ::Hash
-  K = type_member(fixed: T.untyped)
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.untyped}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 end
 
 class ActiveSupport::OrderedOptions < ::Hash
-  K = type_member(fixed: T.untyped)
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.untyped}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 end
 
 ActiveSupport::ParameterFilter::FILTERED = T.let(T.unsafe(nil), String)

--- a/lib/graphql/all/graphql.rbi
+++ b/lib/graphql/all/graphql.rbi
@@ -10,7 +10,7 @@ end
 class GraphQL::Backtrace
   include(::Enumerable)
   extend(::Forwardable)
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 end
 
 class GraphQL::Schema

--- a/lib/httparty/all/httparty.rbi
+++ b/lib/httparty/all/httparty.rbi
@@ -117,9 +117,9 @@ HTTParty::ConnectionAdapter::OPTION_DEFAULTS = T.let(T.unsafe(nil), T::Hash[T.un
 HTTParty::ConnectionAdapter::StripIpv6BracketsRegex = T.let(T.unsafe(nil), Regexp)
 
 class HTTParty::CookieHash < ::Hash
-  K = type_member(fixed: T.untyped)
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.untyped}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 
   def add_cookies(data); end
   def to_cookie_string; end

--- a/lib/net-sftp/all/net-sftp.rbi
+++ b/lib/net-sftp/all/net-sftp.rbi
@@ -321,7 +321,7 @@ end
 Net::SFTP::Operations::Download::DEFAULT_READ_SIZE = T.let(T.unsafe(nil), Integer)
 
 class Net::SFTP::Operations::Download::Entry < ::Struct
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def directory; end
   def directory=(_); end
@@ -412,7 +412,7 @@ end
 Net::SFTP::Operations::Upload::DEFAULT_READ_SIZE = T.let(T.unsafe(nil), Integer)
 
 class Net::SFTP::Operations::Upload::LiveFile < ::Struct
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def handle; end
   def handle=(_); end
@@ -642,7 +642,7 @@ class Net::SFTP::Protocol::V04::Attributes < ::Net::SFTP::Protocol::V01::Attribu
 end
 
 class Net::SFTP::Protocol::V04::Attributes::ACL < ::Struct
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def flag; end
   def flag=(_); end

--- a/lib/net-ssh/all/net-ssh.rbi
+++ b/lib/net-ssh/all/net-ssh.rbi
@@ -840,7 +840,7 @@ end
 
 class Net::SSH::HostKeys
   include(::Enumerable)
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def initialize(host_keys, host, known_hosts, options = T.unsafe(nil)); end
 
@@ -965,7 +965,7 @@ class Net::SSH::Service::Forward
 end
 
 class Net::SSH::Service::Forward::Remote < ::Struct
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def host; end
   def host=(_); end

--- a/lib/railties/all/railties.rbi
+++ b/lib/railties/all/railties.rbi
@@ -33,9 +33,9 @@ end
 Rails::Application::INITIAL_VARIABLES = T.let(T.unsafe(nil), T::Array[T.untyped])
 
 class Rails::Application::NonSymbolAccessDeprecatedHash < ::ActiveSupport::HashWithIndifferentAccess
-  K = type_member(fixed: T.untyped)
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.untyped}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 end
 
 module Rails::Command::Behavior

--- a/lib/sidekiq/all/sidekiq.rbi
+++ b/lib/sidekiq/all/sidekiq.rbi
@@ -68,7 +68,7 @@ Sidekiq::DEFAULTS = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 Sidekiq::DEFAULT_WORKER_OPTIONS = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 
 class Sidekiq::DeadSet < ::Sidekiq::JobSet
-  Elem = type_member(fixed: Sidekiq::SortedEntry)
+  Elem = type_member {{fixed: Sidekiq::SortedEntry}}
 
   def initialize; end
 
@@ -226,7 +226,7 @@ class Sidekiq::JobRetry::Skip < ::Sidekiq::JobRetry::Handled
 end
 
 class Sidekiq::JobSet < ::Sidekiq::SortedSet
-  Elem = type_member(fixed: Sidekiq::SortedEntry)
+  Elem = type_member {{fixed: Sidekiq::SortedEntry}}
 
   def delete(score, jid); end
   def delete_by_jid(score, jid); end
@@ -275,7 +275,7 @@ end
 
 class Sidekiq::Middleware::Chain
   include(::Enumerable)
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def initialize; end
 
@@ -325,7 +325,7 @@ end
 class Sidekiq::ProcessSet
   include(::Enumerable)
   include(::Sidekiq::RedisScanner)
-  Elem = type_member(fixed: Sidekiq::Process)
+  Elem = type_member {{fixed: Sidekiq::Process}}
 
   def initialize(clean_plz = T.unsafe(nil)); end
 
@@ -338,7 +338,7 @@ end
 class Sidekiq::Queue
   include(::Enumerable)
   extend(::Sidekiq::RedisScanner)
-  Elem = type_member(fixed: Sidekiq::Job)
+  Elem = type_member {{fixed: Sidekiq::Job}}
 
   def initialize(name = T.unsafe(nil)); end
 
@@ -400,7 +400,7 @@ module Sidekiq::RedisScanner
 end
 
 class Sidekiq::RetrySet < ::Sidekiq::JobSet
-  Elem = type_member(fixed: Sidekiq::SortedEntry)
+  Elem = type_member {{fixed: Sidekiq::SortedEntry}}
 
   def initialize; end
 
@@ -440,7 +440,7 @@ Sidekiq::Scheduled::Poller::INITIAL_WAIT = T.let(T.unsafe(nil), Integer)
 Sidekiq::Scheduled::SETS = T.let(T.unsafe(nil), T::Array[T.untyped])
 
 class Sidekiq::ScheduledSet < ::Sidekiq::JobSet
-  Elem = type_member(fixed: Sidekiq::SortedEntry)
+  Elem = type_member {{fixed: Sidekiq::SortedEntry}}
 
   def initialize; end
 end
@@ -468,7 +468,7 @@ end
 
 class Sidekiq::SortedSet
   include(::Enumerable)
-  Elem = type_member(fixed: Sidekiq::SortedEntry)
+  Elem = type_member {{fixed: Sidekiq::SortedEntry}}
 
   def initialize(name); end
 
@@ -626,7 +626,7 @@ end
 class Sidekiq::Workers
   include(::Enumerable)
   include(::Sidekiq::RedisScanner)
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def each; end
   def size; end

--- a/lib/thor/all/thor.rbi
+++ b/lib/thor/all/thor.rbi
@@ -354,7 +354,7 @@ module Thor::Base::ClassMethods
 end
 
 class Thor::Command < ::Struct
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def initialize(name, description, long_description, usage, options = T.unsafe(nil)); end
 
@@ -385,9 +385,9 @@ module Thor::CoreExt
 end
 
 class Thor::CoreExt::HashWithIndifferentAccess < ::Hash
-  K = type_member(fixed: T.untyped)
-  V = type_member(fixed: T.untyped)
-  Elem = type_member(fixed: T.untyped)
+  K = type_member {{fixed: T.untyped}}
+  V = type_member {{fixed: T.untyped}}
+  Elem = type_member {{fixed: T.untyped}}
 
   def initialize(hash = T.unsafe(nil)); end
 
@@ -413,7 +413,7 @@ end
 Thor::Correctable = DidYouMean::Correctable
 
 class Thor::DynamicCommand < ::Thor::Command
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def initialize(name, options = T.unsafe(nil)); end
 
@@ -466,7 +466,7 @@ end
 Thor::HELP_MAPPINGS = T.let(T.unsafe(nil), T::Array[T.untyped])
 
 class Thor::HiddenCommand < ::Thor::Command
-  Elem = type_member(fixed: T.untyped)
+  Elem = type_member {{fixed: T.untyped}}
 
   def hidden?; end
 end


### PR DESCRIPTION
This syntax is newly available as of version Sorbet 0.5.9889.

It will become the required syntax once this PR lands:

<https://github.com/sorbet/sorbet/pull/5639>

If you cannot upgrade to that version of Sorbet, you should pass this
environment variable to `srb rbi` to pin the version of sorbet-typed to
a previous version:

```
SRB_SORBET_TYPED_REVISION=d15728d555a02f160d2d2348b7219642b6a00804
```

That commit is the most recent sorbet-typed master commit before these
changes (linkified: d15728d555a02f160d2d2348b7219642b6a00804).