### PR TITLE
Update ActionMailer mail return type

### DIFF
--- a/lib/actionmailer/all/actionmailer.rbi
+++ b/lib/actionmailer/all/actionmailer.rbi
@@ -1,6 +1,6 @@
 # typed: strong
 
 class ActionMailer::Base
-  sig { params(headers: T.untyped).returns(Mail::Message) }
+  sig { params(headers: T.untyped).returns(ActionMailer::MessageDelivery) }
   def mail(headers = nil, &block); end
 end


### PR DESCRIPTION
The return type is actually `ActionMailer::MessageDelivery` which is a wrapper around `Mail::Message`. I've tested this on Rails 5.2, 6.1, and 7.0 and they all return the same class.

To test, I created a dummy mailer method in ApplicationMailer:
```
class ApplicationMailer < ActionMailer::Base
  default from: "from@example.com"
  layout "mailer"

  def mailer
    mail to: 'test@example.com', subject: 'Test'
  end
end
```

Then fired up rails console and did:
```
ApplicationMailer.mailer.class
=> ActionMailer::MessageDelivery
```

The `Mail::Message` object is accessible as the message on the mailer: `ApplicationMailer.mailer.message.class`