### PR TITLE
Add root log to yard.rbi

### DIFF
--- a/lib/yard/all/yard.rbi
+++ b/lib/yard/all/yard.rbi
@@ -1,5 +1,8 @@
 # typed: true
 
+sig { returns(YARD::Logger) }
+def log; end
+
 class YARD::CodeObjects::Base
   def initialize(namespace, name, *arg2); end
 end

--- a/lib/yard/all/yard_test.rb
+++ b/lib/yard/all/yard_test.rb
@@ -16,3 +16,5 @@ YARD::CodeObjects::ConstantObject.new(namespace, 'Spades')
 
 YARD::CodeObjects::Proxy.new(namespace, 'C')
 YARD::CodeObjects::Proxy.new(namespace, 'M', :module)
+
+log.warn('test')


### PR DESCRIPTION
Adds the `log` method in an attempt to solve the problem posted [here](https://sorbet-ruby.slack.com/archives/C02VD06EQ3U/p1659826763215239) (and pasted below):

I'm attempting to migrate `yard-sorbet` to use `tapioca` for RBI generation. WIP PR: https://github.com/dduugg/yard-sorbet/pull/103
I'm following the migration guide: https://github.com/Shopify/tapioca/wiki/Migrating-to-Tapioca
However, typechecking is currently failing:
```
$ be srb tc                                                                                                                         [15:52:16]
lib/yard-sorbet/sig_to_yard.rb:60: Method log does not exist on T.class_of(YARDSorbet::SigToYARD) https://srb.help/7003
    60 |        log.info("Unsupported sig aref node #{node.source}")
                ^^^

lib/yard-sorbet/sig_to_yard.rb:126: Method log does not exist on T.class_of(YARDSorbet::SigToYARD) https://srb.help/7003
     126 |      log.warn("Unsupported sig #{node.type} node #{node.source}")
                ^^^
Errors: 2
FAIL
```
`log` is defined by `yard` here: https://github.com/lsegal/yard/blob/main/lib/yard/globals.rb#L20-L22
My understanding is that I should be able to resolve this by adding requiring `yard/globals` in `tapioca/require`, then invoking `bin/tapioca gem yard`, which I attempted to do in these commits:
https://github.com/dduugg/yard-sorbet/pull/103/commits/9e00ecd7e14c5ce25defb10d1273c69d9dfd9569
https://github.com/dduugg/yard-sorbet/pull/103/commits/87171343b2e26c1a6a872d6ccd1513832db2a920
However, I'm still seeing the same errors when I attempt to invoke `srb tc`
What am I doing wrong?
