### PR TITLE
Revert "Update ActionMailer mail return type (#394)"

### DIFF
--- a/lib/actionmailer/all/actionmailer.rbi
+++ b/lib/actionmailer/all/actionmailer.rbi
@@ -1,6 +1,6 @@
 # typed: strong
 
 class ActionMailer::Base
-  sig { params(headers: T.untyped).returns(ActionMailer::MessageDelivery) }
+  sig { params(headers: T.untyped).returns(Mail::Message) }
   def mail(headers = nil, &block); end
 end


### PR DESCRIPTION
This reverts the commit from #394. That was an incorrect change, which @leifg describes in detail here: https://github.com/Shopify/rbi-central/issues/123#issuecomment-1301067970