### PR TITLE
Have ActionController::API inherit from Metal

### DIFF
--- a/lib/actionpack/all/actionpack.rbi
+++ b/lib/actionpack/all/actionpack.rbi
@@ -181,7 +181,7 @@ class ActionController::Base < ::ActionController::Metal
   include(::ActiveSupport::Rescuable)
 end
 
-class ActionController::API
+class ActionController::API < ::ActionController::Metal
   MODULES = T.let(T.unsafe(nil), T::Array[T.untyped])
 end
 


### PR DESCRIPTION
This reflects actual inheritance, and exposes accessor methods like request and response on ActionController::API.